### PR TITLE
feat(evaluators): add Faithfulness evaluator

### DIFF
--- a/src/ragnarok_ai/evaluators/__init__.py
+++ b/src/ragnarok_ai/evaluators/__init__.py
@@ -6,6 +6,11 @@ including retrieval quality and generation quality metrics.
 
 from __future__ import annotations
 
+from ragnarok_ai.evaluators.faithfulness import (
+    ClaimVerification,
+    FaithfulnessEvaluator,
+    FaithfulnessResult,
+)
 from ragnarok_ai.evaluators.retrieval import (
     RetrievalMetrics,
     evaluate_retrieval,
@@ -16,6 +21,9 @@ from ragnarok_ai.evaluators.retrieval import (
 )
 
 __all__ = [
+    "ClaimVerification",
+    "FaithfulnessEvaluator",
+    "FaithfulnessResult",
     "RetrievalMetrics",
     "evaluate_retrieval",
     "mrr",

--- a/src/ragnarok_ai/evaluators/faithfulness.py
+++ b/src/ragnarok_ai/evaluators/faithfulness.py
@@ -1,0 +1,317 @@
+"""Faithfulness evaluator for ragnarok-ai.
+
+This module provides LLM-based evaluation of faithfulness,
+measuring if generated answers are grounded in retrieved context.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+
+from ragnarok_ai.core.exceptions import EvaluationError
+
+if TYPE_CHECKING:
+    from ragnarok_ai.core.protocols import LLMProtocol
+
+
+class ClaimVerification(BaseModel):
+    """Verification result for a single claim.
+
+    Attributes:
+        claim: The extracted claim from the response.
+        supported: Whether the claim is supported by the context.
+        reasoning: Explanation for the verification decision.
+    """
+
+    model_config = {"frozen": True}
+
+    claim: str = Field(..., description="The extracted claim")
+    supported: bool = Field(..., description="Whether the claim is supported by context")
+    reasoning: str = Field(..., description="Explanation for the decision")
+
+
+class FaithfulnessResult(BaseModel):
+    """Detailed result of faithfulness evaluation.
+
+    Attributes:
+        score: Faithfulness score between 0.0 and 1.0.
+        claims: List of extracted claims with verification results.
+        reasoning: Overall reasoning for the score.
+    """
+
+    model_config = {"frozen": True}
+
+    score: float = Field(..., ge=0.0, le=1.0, description="Faithfulness score")
+    claims: list[ClaimVerification] = Field(..., description="Claim verifications")
+    reasoning: str = Field(..., description="Overall reasoning")
+
+
+# Prompt for extracting claims from the response
+CLAIM_EXTRACTION_PROMPT = """Extract all factual claims from the following response.
+A claim is a single, atomic statement that can be verified as true or false.
+
+Response: {response}
+
+Return a JSON array of claims. Example format:
+["Paris is the capital of France", "The Eiffel Tower is 330 meters tall"]
+
+Only return the JSON array, nothing else."""
+
+# Prompt for verifying claims against context
+CLAIM_VERIFICATION_PROMPT = """Verify if the following claim is supported by the given context.
+
+Claim: {claim}
+
+Context: {context}
+
+Answer with a JSON object containing:
+- "supported": true if the claim is clearly supported by the context, false otherwise
+- "reasoning": brief explanation for your decision
+
+Only return the JSON object, nothing else."""
+
+
+class FaithfulnessEvaluator:
+    """LLM-based faithfulness evaluator.
+
+    Measures if generated answers are grounded in retrieved context
+    using an LLM-as-judge approach.
+
+    The evaluation process:
+    1. Extract claims from the generated response
+    2. Verify each claim against the provided context
+    3. Calculate score as: supported_claims / total_claims
+
+    Implements EvaluatorProtocol for use in evaluation pipelines.
+
+    Attributes:
+        llm: The LLM provider for claim extraction and verification.
+
+    Example:
+        >>> from ragnarok_ai.adapters import OllamaLLM
+        >>> async with OllamaLLM() as llm:
+        ...     evaluator = FaithfulnessEvaluator(llm)
+        ...     score = await evaluator.evaluate(
+        ...         response="Paris is the capital of France.",
+        ...         context="France is a country in Europe. Its capital is Paris."
+        ...     )
+        ...     print(f"Faithfulness: {score:.2f}")
+    """
+
+    def __init__(self, llm: LLMProtocol) -> None:
+        """Initialize FaithfulnessEvaluator.
+
+        Args:
+            llm: The LLM provider implementing LLMProtocol.
+        """
+        self.llm = llm
+
+    async def evaluate(
+        self,
+        response: str,
+        context: str,
+        query: str | None = None,  # noqa: ARG002
+    ) -> float:
+        """Evaluate faithfulness of a response to its context.
+
+        Args:
+            response: The generated response to evaluate.
+            context: The retrieved context used for generation.
+            query: Optional original query (unused, for protocol compatibility).
+
+        Returns:
+            Faithfulness score between 0.0 and 1.0.
+
+        Raises:
+            EvaluationError: If evaluation fails.
+        """
+        result = await self.evaluate_detailed(response, context)
+        return result.score
+
+    async def evaluate_detailed(
+        self,
+        response: str,
+        context: str,
+    ) -> FaithfulnessResult:
+        """Evaluate faithfulness with detailed claim-level results.
+
+        Args:
+            response: The generated response to evaluate.
+            context: The retrieved context used for generation.
+
+        Returns:
+            FaithfulnessResult with score, claims, and reasoning.
+
+        Raises:
+            EvaluationError: If evaluation fails.
+        """
+        # Handle empty response
+        if not response.strip():
+            return FaithfulnessResult(
+                score=1.0,
+                claims=[],
+                reasoning="Empty response has no claims to verify.",
+            )
+
+        # Handle empty context
+        if not context.strip():
+            return FaithfulnessResult(
+                score=0.0,
+                claims=[],
+                reasoning="No context provided to verify claims against.",
+            )
+
+        # Extract claims from response
+        claims = await self._extract_claims(response)
+
+        if not claims:
+            return FaithfulnessResult(
+                score=1.0,
+                claims=[],
+                reasoning="No verifiable claims found in the response.",
+            )
+
+        # Verify each claim against context
+        verifications: list[ClaimVerification] = []
+        for claim in claims:
+            verification = await self._verify_claim(claim, context)
+            verifications.append(verification)
+
+        # Calculate score
+        supported_count = sum(1 for v in verifications if v.supported)
+        score = supported_count / len(verifications)
+
+        # Generate overall reasoning
+        if score == 1.0:
+            reasoning = "All claims in the response are supported by the context."
+        elif score == 0.0:
+            reasoning = "None of the claims in the response are supported by the context."
+        else:
+            reasoning = f"{supported_count} out of {len(verifications)} claims are supported by the context."
+
+        return FaithfulnessResult(
+            score=score,
+            claims=verifications,
+            reasoning=reasoning,
+        )
+
+    async def _extract_claims(self, response: str) -> list[str]:
+        """Extract factual claims from a response.
+
+        Args:
+            response: The response to extract claims from.
+
+        Returns:
+            List of extracted claims.
+
+        Raises:
+            EvaluationError: If claim extraction fails.
+        """
+        prompt = CLAIM_EXTRACTION_PROMPT.format(response=response)
+
+        try:
+            llm_response = await self.llm.generate(prompt)
+            claims = self._parse_json_array(llm_response)
+            return [str(claim) for claim in claims if claim]
+        except Exception as e:
+            msg = f"Failed to extract claims: {e}"
+            raise EvaluationError(msg) from e
+
+    async def _verify_claim(self, claim: str, context: str) -> ClaimVerification:
+        """Verify a single claim against context.
+
+        Args:
+            claim: The claim to verify.
+            context: The context to verify against.
+
+        Returns:
+            ClaimVerification with supported status and reasoning.
+
+        Raises:
+            EvaluationError: If verification fails.
+        """
+        prompt = CLAIM_VERIFICATION_PROMPT.format(claim=claim, context=context)
+
+        try:
+            llm_response = await self.llm.generate(prompt)
+            result = self._parse_json_object(llm_response)
+
+            supported = bool(result.get("supported", False))
+            reasoning = str(result.get("reasoning", "No reasoning provided."))
+
+            return ClaimVerification(
+                claim=claim,
+                supported=supported,
+                reasoning=reasoning,
+            )
+        except Exception as e:
+            msg = f"Failed to verify claim '{claim}': {e}"
+            raise EvaluationError(msg) from e
+
+    def _parse_json_array(self, text: str) -> list[str]:
+        """Parse a JSON array from LLM response.
+
+        Args:
+            text: The LLM response text.
+
+        Returns:
+            Parsed list of strings.
+        """
+        # Try to find JSON array in the response
+        text = text.strip()
+
+        # Try direct parse first
+        try:
+            result = json.loads(text)
+            if isinstance(result, list):
+                return result
+        except json.JSONDecodeError:
+            pass
+
+        # Try to extract JSON array from text
+        match = re.search(r"\[.*\]", text, re.DOTALL)
+        if match:
+            try:
+                result = json.loads(match.group())
+                if isinstance(result, list):
+                    return result
+            except json.JSONDecodeError:
+                pass
+
+        return []
+
+    def _parse_json_object(self, text: str) -> dict[str, object]:
+        """Parse a JSON object from LLM response.
+
+        Args:
+            text: The LLM response text.
+
+        Returns:
+            Parsed dictionary.
+        """
+        # Try to find JSON object in the response
+        text = text.strip()
+
+        # Try direct parse first
+        try:
+            result = json.loads(text)
+            if isinstance(result, dict):
+                return result
+        except json.JSONDecodeError:
+            pass
+
+        # Try to extract JSON object from text
+        match = re.search(r"\{.*\}", text, re.DOTALL)
+        if match:
+            try:
+                result = json.loads(match.group())
+                if isinstance(result, dict):
+                    return result
+            except json.JSONDecodeError:
+                pass
+
+        return {}

--- a/tests/unit/test_faithfulness.py
+++ b/tests/unit/test_faithfulness.py
@@ -1,0 +1,416 @@
+"""Tests for Faithfulness evaluator."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ragnarok_ai.core.exceptions import EvaluationError
+from ragnarok_ai.evaluators.faithfulness import (
+    ClaimVerification,
+    FaithfulnessEvaluator,
+    FaithfulnessResult,
+)
+
+
+class TestFaithfulnessEvaluatorInit:
+    """Tests for FaithfulnessEvaluator initialization."""
+
+    def test_init_with_llm(self) -> None:
+        """Evaluator stores the LLM reference."""
+        mock_llm = AsyncMock()
+        evaluator = FaithfulnessEvaluator(llm=mock_llm)
+
+        assert evaluator.llm is mock_llm
+
+
+class TestFaithfulnessEvaluatorEvaluate:
+    """Tests for FaithfulnessEvaluator.evaluate method."""
+
+    @pytest.mark.asyncio
+    async def test_evaluate_all_claims_supported(self) -> None:
+        """Returns 1.0 when all claims are supported."""
+        mock_llm = AsyncMock()
+        # First call: extract claims
+        mock_llm.generate.side_effect = [
+            '["Paris is the capital of France"]',
+            '{"supported": true, "reasoning": "The context states Paris is the capital."}',
+        ]
+
+        evaluator = FaithfulnessEvaluator(llm=mock_llm)
+        score = await evaluator.evaluate(
+            response="Paris is the capital of France.",
+            context="France is a country in Europe. Its capital is Paris.",
+        )
+
+        assert score == 1.0
+
+    @pytest.mark.asyncio
+    async def test_evaluate_no_claims_supported(self) -> None:
+        """Returns 0.0 when no claims are supported."""
+        mock_llm = AsyncMock()
+        mock_llm.generate.side_effect = [
+            '["Berlin is the capital of France"]',
+            '{"supported": false, "reasoning": "The context says Paris is the capital, not Berlin."}',
+        ]
+
+        evaluator = FaithfulnessEvaluator(llm=mock_llm)
+        score = await evaluator.evaluate(
+            response="Berlin is the capital of France.",
+            context="France is a country in Europe. Its capital is Paris.",
+        )
+
+        assert score == 0.0
+
+    @pytest.mark.asyncio
+    async def test_evaluate_partial_support(self) -> None:
+        """Returns partial score when some claims are supported."""
+        mock_llm = AsyncMock()
+        mock_llm.generate.side_effect = [
+            '["Paris is the capital of France", "France has 100 million people"]',
+            '{"supported": true, "reasoning": "Context confirms Paris is the capital."}',
+            '{"supported": false, "reasoning": "Population not mentioned in context."}',
+        ]
+
+        evaluator = FaithfulnessEvaluator(llm=mock_llm)
+        score = await evaluator.evaluate(
+            response="Paris is the capital of France. France has 100 million people.",
+            context="France is a country in Europe. Its capital is Paris.",
+        )
+
+        assert score == 0.5
+
+    @pytest.mark.asyncio
+    async def test_evaluate_empty_response(self) -> None:
+        """Returns 1.0 for empty response (no claims to verify)."""
+        mock_llm = AsyncMock()
+
+        evaluator = FaithfulnessEvaluator(llm=mock_llm)
+        score = await evaluator.evaluate(
+            response="",
+            context="Some context here.",
+        )
+
+        assert score == 1.0
+        mock_llm.generate.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_evaluate_empty_context(self) -> None:
+        """Returns 0.0 for empty context (nothing to verify against)."""
+        mock_llm = AsyncMock()
+
+        evaluator = FaithfulnessEvaluator(llm=mock_llm)
+        score = await evaluator.evaluate(
+            response="Paris is the capital.",
+            context="",
+        )
+
+        assert score == 0.0
+        mock_llm.generate.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_evaluate_no_claims_extracted(self) -> None:
+        """Returns 1.0 when no claims can be extracted."""
+        mock_llm = AsyncMock()
+        mock_llm.generate.return_value = "[]"
+
+        evaluator = FaithfulnessEvaluator(llm=mock_llm)
+        score = await evaluator.evaluate(
+            response="Hello!",
+            context="Some context.",
+        )
+
+        assert score == 1.0
+
+    @pytest.mark.asyncio
+    async def test_evaluate_query_parameter_ignored(self) -> None:
+        """Query parameter is accepted but not used."""
+        mock_llm = AsyncMock()
+        mock_llm.generate.side_effect = [
+            '["Paris is the capital"]',
+            '{"supported": true, "reasoning": "Confirmed."}',
+        ]
+
+        evaluator = FaithfulnessEvaluator(llm=mock_llm)
+        score = await evaluator.evaluate(
+            response="Paris is the capital.",
+            context="Its capital is Paris.",
+            query="What is the capital?",
+        )
+
+        assert score == 1.0
+
+
+class TestFaithfulnessEvaluatorEvaluateDetailed:
+    """Tests for FaithfulnessEvaluator.evaluate_detailed method."""
+
+    @pytest.mark.asyncio
+    async def test_evaluate_detailed_returns_result(self) -> None:
+        """Returns FaithfulnessResult with claims and reasoning."""
+        mock_llm = AsyncMock()
+        mock_llm.generate.side_effect = [
+            '["Paris is the capital of France"]',
+            '{"supported": true, "reasoning": "The context confirms this."}',
+        ]
+
+        evaluator = FaithfulnessEvaluator(llm=mock_llm)
+        result = await evaluator.evaluate_detailed(
+            response="Paris is the capital of France.",
+            context="France is a country. Its capital is Paris.",
+        )
+
+        assert isinstance(result, FaithfulnessResult)
+        assert result.score == 1.0
+        assert len(result.claims) == 1
+        assert result.claims[0].claim == "Paris is the capital of France"
+        assert result.claims[0].supported is True
+        assert "confirms" in result.claims[0].reasoning
+        assert "All claims" in result.reasoning
+
+    @pytest.mark.asyncio
+    async def test_evaluate_detailed_multiple_claims(self) -> None:
+        """Handles multiple claims correctly."""
+        mock_llm = AsyncMock()
+        mock_llm.generate.side_effect = [
+            '["Claim 1", "Claim 2", "Claim 3"]',
+            '{"supported": true, "reasoning": "Reason 1"}',
+            '{"supported": false, "reasoning": "Reason 2"}',
+            '{"supported": true, "reasoning": "Reason 3"}',
+        ]
+
+        evaluator = FaithfulnessEvaluator(llm=mock_llm)
+        result = await evaluator.evaluate_detailed(
+            response="Response with multiple claims.",
+            context="Some context.",
+        )
+
+        assert result.score == pytest.approx(2 / 3)
+        assert len(result.claims) == 3
+        assert result.claims[0].supported is True
+        assert result.claims[1].supported is False
+        assert result.claims[2].supported is True
+        assert "2 out of 3" in result.reasoning
+
+    @pytest.mark.asyncio
+    async def test_evaluate_detailed_empty_response(self) -> None:
+        """Empty response returns appropriate result."""
+        mock_llm = AsyncMock()
+
+        evaluator = FaithfulnessEvaluator(llm=mock_llm)
+        result = await evaluator.evaluate_detailed(
+            response="   ",
+            context="Some context.",
+        )
+
+        assert result.score == 1.0
+        assert result.claims == []
+        assert "Empty response" in result.reasoning
+
+    @pytest.mark.asyncio
+    async def test_evaluate_detailed_no_claims(self) -> None:
+        """No claims returns appropriate result."""
+        mock_llm = AsyncMock()
+        mock_llm.generate.return_value = "[]"
+
+        evaluator = FaithfulnessEvaluator(llm=mock_llm)
+        result = await evaluator.evaluate_detailed(
+            response="Hello there!",
+            context="Some context.",
+        )
+
+        assert result.score == 1.0
+        assert result.claims == []
+        assert "No verifiable claims" in result.reasoning
+
+
+class TestFaithfulnessEvaluatorClaimExtraction:
+    """Tests for claim extraction logic."""
+
+    @pytest.mark.asyncio
+    async def test_extract_claims_json_array(self) -> None:
+        """Extracts claims from valid JSON array."""
+        mock_llm = AsyncMock()
+        mock_llm.generate.side_effect = [
+            '["Claim A", "Claim B"]',
+            '{"supported": true, "reasoning": "OK"}',
+            '{"supported": true, "reasoning": "OK"}',
+        ]
+
+        evaluator = FaithfulnessEvaluator(llm=mock_llm)
+        result = await evaluator.evaluate_detailed("Response", "Context")
+
+        assert len(result.claims) == 2
+        assert result.claims[0].claim == "Claim A"
+        assert result.claims[1].claim == "Claim B"
+
+    @pytest.mark.asyncio
+    async def test_extract_claims_with_surrounding_text(self) -> None:
+        """Extracts claims from JSON array embedded in text."""
+        mock_llm = AsyncMock()
+        mock_llm.generate.side_effect = [
+            'Here are the claims: ["Claim X"] and that\'s it.',
+            '{"supported": true, "reasoning": "Found."}',
+        ]
+
+        evaluator = FaithfulnessEvaluator(llm=mock_llm)
+        result = await evaluator.evaluate_detailed("Response", "Context")
+
+        assert len(result.claims) == 1
+        assert result.claims[0].claim == "Claim X"
+
+    @pytest.mark.asyncio
+    async def test_extract_claims_invalid_json(self) -> None:
+        """Raises EvaluationError on invalid JSON."""
+        mock_llm = AsyncMock()
+        mock_llm.generate.side_effect = Exception("LLM error")
+
+        evaluator = FaithfulnessEvaluator(llm=mock_llm)
+
+        with pytest.raises(EvaluationError, match="Failed to extract claims"):
+            await evaluator.evaluate_detailed("Response", "Context")
+
+
+class TestFaithfulnessEvaluatorClaimVerification:
+    """Tests for claim verification logic."""
+
+    @pytest.mark.asyncio
+    async def test_verify_claim_supported(self) -> None:
+        """Correctly identifies supported claim."""
+        mock_llm = AsyncMock()
+        mock_llm.generate.side_effect = [
+            '["The sky is blue"]',
+            '{"supported": true, "reasoning": "Context mentions blue sky."}',
+        ]
+
+        evaluator = FaithfulnessEvaluator(llm=mock_llm)
+        result = await evaluator.evaluate_detailed("The sky is blue.", "The sky is blue.")
+
+        assert result.claims[0].supported is True
+
+    @pytest.mark.asyncio
+    async def test_verify_claim_not_supported(self) -> None:
+        """Correctly identifies unsupported claim."""
+        mock_llm = AsyncMock()
+        mock_llm.generate.side_effect = [
+            '["The sky is green"]',
+            '{"supported": false, "reasoning": "Context says sky is blue."}',
+        ]
+
+        evaluator = FaithfulnessEvaluator(llm=mock_llm)
+        result = await evaluator.evaluate_detailed("The sky is green.", "The sky is blue.")
+
+        assert result.claims[0].supported is False
+
+    @pytest.mark.asyncio
+    async def test_verify_claim_json_with_text(self) -> None:
+        """Parses verification result with surrounding text."""
+        mock_llm = AsyncMock()
+        mock_llm.generate.side_effect = [
+            '["Claim"]',
+            'Based on analysis: {"supported": true, "reasoning": "Found it."}',
+        ]
+
+        evaluator = FaithfulnessEvaluator(llm=mock_llm)
+        result = await evaluator.evaluate_detailed("Response", "Context")
+
+        assert result.claims[0].supported is True
+
+    @pytest.mark.asyncio
+    async def test_verify_claim_llm_error(self) -> None:
+        """Raises EvaluationError on verification failure."""
+        mock_llm = AsyncMock()
+        mock_llm.generate.side_effect = [
+            '["Claim"]',
+            Exception("Verification failed"),
+        ]
+
+        evaluator = FaithfulnessEvaluator(llm=mock_llm)
+
+        with pytest.raises(EvaluationError, match="Failed to verify claim"):
+            await evaluator.evaluate_detailed("Response", "Context")
+
+
+class TestFaithfulnessEvaluatorProtocolCompliance:
+    """Tests for EvaluatorProtocol compliance."""
+
+    def test_implements_protocol(self) -> None:
+        """FaithfulnessEvaluator implements EvaluatorProtocol."""
+        from ragnarok_ai.core.protocols import EvaluatorProtocol
+
+        mock_llm = AsyncMock()
+        evaluator = FaithfulnessEvaluator(llm=mock_llm)
+
+        assert isinstance(evaluator, EvaluatorProtocol)
+
+    def test_has_evaluate_method(self) -> None:
+        """FaithfulnessEvaluator has evaluate method."""
+        mock_llm = AsyncMock()
+        evaluator = FaithfulnessEvaluator(llm=mock_llm)
+
+        assert hasattr(evaluator, "evaluate")
+        assert callable(evaluator.evaluate)
+
+
+class TestClaimVerificationModel:
+    """Tests for ClaimVerification model."""
+
+    def test_create_claim_verification(self) -> None:
+        """ClaimVerification can be created with valid data."""
+        verification = ClaimVerification(
+            claim="Test claim",
+            supported=True,
+            reasoning="Test reasoning",
+        )
+
+        assert verification.claim == "Test claim"
+        assert verification.supported is True
+        assert verification.reasoning == "Test reasoning"
+
+    def test_claim_verification_is_frozen(self) -> None:
+        """ClaimVerification is immutable."""
+        from pydantic import ValidationError
+
+        verification = ClaimVerification(
+            claim="Test",
+            supported=True,
+            reasoning="Reason",
+        )
+
+        with pytest.raises(ValidationError):
+            verification.claim = "New claim"
+
+
+class TestFaithfulnessResultModel:
+    """Tests for FaithfulnessResult model."""
+
+    def test_create_faithfulness_result(self) -> None:
+        """FaithfulnessResult can be created with valid data."""
+        result = FaithfulnessResult(
+            score=0.75,
+            claims=[],
+            reasoning="Test reasoning",
+        )
+
+        assert result.score == 0.75
+        assert result.claims == []
+        assert result.reasoning == "Test reasoning"
+
+    def test_score_validation(self) -> None:
+        """Score must be between 0 and 1."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            FaithfulnessResult(score=1.5, claims=[], reasoning="Invalid")
+
+        with pytest.raises(ValidationError):
+            FaithfulnessResult(score=-0.1, claims=[], reasoning="Invalid")
+
+    def test_faithfulness_result_is_frozen(self) -> None:
+        """FaithfulnessResult is immutable."""
+        from pydantic import ValidationError
+
+        result = FaithfulnessResult(score=1.0, claims=[], reasoning="OK")
+
+        with pytest.raises(ValidationError):
+            result.score = 0.5


### PR DESCRIPTION
## Summary

- Implement FaithfulnessEvaluator with LLM-as-judge approach
- Claim extraction and verification against context
- Score = supported_claims / total_claims
- FaithfulnessResult with detailed claim-level reasoning
- Implements EvaluatorProtocol
- Include 26 unit tests

Closes #2

## Test plan

- [x] All 193 tests pass
- [x] Lint and type checks pass