### PR TITLE
feat(evaluators): add Hallucination detector

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ metrics.log_to("./metrics/")  # Time-series storage
 - [x] Qdrant adapter
 - [x] Faithfulness evaluator
 - [x] Relevance evaluator
-- [ ] Hallucination detection
+- [x] Hallucination detection
 - [ ] HTML report with drill-down (failed questions, retrieved chunks)
 - [ ] Intelligent CI gating (stable metrics fail, LLM judgments warn)
 

--- a/src/ragnarok_ai/evaluators/__init__.py
+++ b/src/ragnarok_ai/evaluators/__init__.py
@@ -11,6 +11,11 @@ from ragnarok_ai.evaluators.faithfulness import (
     FaithfulnessEvaluator,
     FaithfulnessResult,
 )
+from ragnarok_ai.evaluators.hallucination import (
+    Hallucination,
+    HallucinationDetector,
+    HallucinationResult,
+)
 from ragnarok_ai.evaluators.relevance import (
     RelevanceEvaluator,
     RelevanceResult,
@@ -28,6 +33,9 @@ __all__ = [
     "ClaimVerification",
     "FaithfulnessEvaluator",
     "FaithfulnessResult",
+    "Hallucination",
+    "HallucinationDetector",
+    "HallucinationResult",
     "RelevanceEvaluator",
     "RelevanceResult",
     "RetrievalMetrics",

--- a/src/ragnarok_ai/evaluators/hallucination.py
+++ b/src/ragnarok_ai/evaluators/hallucination.py
@@ -1,0 +1,325 @@
+"""Hallucination detector for ragnarok-ai.
+
+This module provides LLM-based detection of hallucinations,
+identifying fabricated or unsupported information in generated answers.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+
+from ragnarok_ai.core.exceptions import EvaluationError
+
+if TYPE_CHECKING:
+    from ragnarok_ai.core.protocols import LLMProtocol
+
+
+class Hallucination(BaseModel):
+    """A detected hallucination in the response.
+
+    Attributes:
+        claim: The hallucinated claim from the response.
+        reason: Explanation of why this is considered a hallucination.
+    """
+
+    model_config = {"frozen": True}
+
+    claim: str = Field(..., description="The hallucinated claim")
+    reason: str = Field(..., description="Why this is a hallucination")
+
+
+class HallucinationResult(BaseModel):
+    """Detailed result of hallucination detection.
+
+    Attributes:
+        score: Hallucination score between 0.0 (no hallucination) and 1.0 (full hallucination).
+        hallucinations: List of detected hallucinations with explanations.
+        total_claims: Total number of claims extracted from the response.
+        reasoning: Overall reasoning for the score.
+    """
+
+    model_config = {"frozen": True}
+
+    score: float = Field(..., ge=0.0, le=1.0, description="Hallucination score (0=good, 1=bad)")
+    hallucinations: list[Hallucination] = Field(default_factory=list, description="Detected hallucinations")
+    total_claims: int = Field(default=0, ge=0, description="Total claims in response")
+    reasoning: str = Field(..., description="Overall reasoning")
+
+
+# Prompt for extracting claims from the response
+CLAIM_EXTRACTION_PROMPT = """Extract all factual claims from the following response.
+A claim is a single, atomic statement that can be verified as true or false.
+
+Response: {response}
+
+Return a JSON array of claims. Example format:
+["Paris is the capital of France", "The Eiffel Tower is 330 meters tall"]
+
+Only return the JSON array, nothing else."""
+
+# Prompt for detecting hallucinations in claims
+HALLUCINATION_DETECTION_PROMPT = """Analyze if the following claim is a hallucination.
+
+A claim is a hallucination if:
+1. It is NOT supported by the given context (fabricated information)
+2. It contradicts the context (false statement)
+
+Claim: {claim}
+
+Context: {context}
+
+Answer with a JSON object containing:
+- "is_hallucination": true if the claim is a hallucination, false if it's supported by the context
+- "reason": brief explanation for your decision
+
+Only return the JSON object, nothing else."""
+
+
+class HallucinationDetector:
+    """LLM-based hallucination detector.
+
+    Detects fabricated or unsupported information in generated answers
+    using an LLM-as-judge approach.
+
+    The detection process:
+    1. Extract claims from the generated response
+    2. Check each claim against the provided context
+    3. Identify claims not supported by or contradicting the context
+    4. Calculate score as: hallucinated_claims / total_claims
+
+    A score of 0.0 means no hallucinations (good), 1.0 means all claims
+    are hallucinations (bad).
+
+    Implements EvaluatorProtocol for use in evaluation pipelines.
+
+    Attributes:
+        llm: The LLM provider for claim extraction and verification.
+
+    Example:
+        >>> from ragnarok_ai.adapters import OllamaLLM
+        >>> async with OllamaLLM() as llm:
+        ...     detector = HallucinationDetector(llm)
+        ...     score = await detector.evaluate(
+        ...         response="Paris, founded in 500 BC, is the capital of France.",
+        ...         context="France is a country in Europe. Its capital is Paris."
+        ...     )
+        ...     print(f"Hallucination rate: {score:.2f}")
+    """
+
+    def __init__(self, llm: LLMProtocol) -> None:
+        """Initialize HallucinationDetector.
+
+        Args:
+            llm: The LLM provider implementing LLMProtocol.
+        """
+        self.llm = llm
+
+    async def evaluate(
+        self,
+        response: str,
+        context: str,
+        query: str | None = None,  # noqa: ARG002
+    ) -> float:
+        """Evaluate hallucination rate of a response.
+
+        Args:
+            response: The generated response to evaluate.
+            context: The retrieved context used for generation.
+            query: Optional original query (unused, for protocol compatibility).
+
+        Returns:
+            Hallucination score between 0.0 (no hallucinations) and 1.0 (all hallucinations).
+
+        Raises:
+            EvaluationError: If evaluation fails.
+        """
+        result = await self.evaluate_detailed(response, context)
+        return result.score
+
+    async def evaluate_detailed(
+        self,
+        response: str,
+        context: str,
+    ) -> HallucinationResult:
+        """Detect hallucinations with detailed results.
+
+        Args:
+            response: The generated response to evaluate.
+            context: The retrieved context used for generation.
+
+        Returns:
+            HallucinationResult with score, hallucinations list, and reasoning.
+
+        Raises:
+            EvaluationError: If evaluation fails.
+        """
+        # Handle empty response
+        if not response.strip():
+            return HallucinationResult(
+                score=0.0,
+                hallucinations=[],
+                total_claims=0,
+                reasoning="Empty response has no claims to check for hallucinations.",
+            )
+
+        # Handle empty context
+        if not context.strip():
+            return HallucinationResult(
+                score=1.0,
+                hallucinations=[],
+                total_claims=0,
+                reasoning="No context provided - all claims are potentially hallucinations.",
+            )
+
+        # Extract claims from response
+        claims = await self._extract_claims(response)
+
+        if not claims:
+            return HallucinationResult(
+                score=0.0,
+                hallucinations=[],
+                total_claims=0,
+                reasoning="No verifiable claims found in the response.",
+            )
+
+        # Check each claim for hallucination
+        hallucinations: list[Hallucination] = []
+        for claim in claims:
+            result = await self._check_hallucination(claim, context)
+            if result is not None:
+                hallucinations.append(result)
+
+        # Calculate score
+        score = len(hallucinations) / len(claims)
+
+        # Generate overall reasoning
+        if not hallucinations:
+            reasoning = "No hallucinations detected. All claims are supported by the context."
+        elif len(hallucinations) == len(claims):
+            reasoning = "All claims in the response are hallucinations (not supported by context)."
+        else:
+            reasoning = f"{len(hallucinations)} out of {len(claims)} claims are hallucinations."
+
+        return HallucinationResult(
+            score=score,
+            hallucinations=hallucinations,
+            total_claims=len(claims),
+            reasoning=reasoning,
+        )
+
+    async def _extract_claims(self, response: str) -> list[str]:
+        """Extract factual claims from a response.
+
+        Args:
+            response: The response to extract claims from.
+
+        Returns:
+            List of extracted claims.
+
+        Raises:
+            EvaluationError: If claim extraction fails.
+        """
+        prompt = CLAIM_EXTRACTION_PROMPT.format(response=response)
+
+        try:
+            llm_response = await self.llm.generate(prompt)
+            claims = self._parse_json_array(llm_response)
+            return [str(claim) for claim in claims if claim]
+        except Exception as e:
+            msg = f"Failed to extract claims: {e}"
+            raise EvaluationError(msg) from e
+
+    async def _check_hallucination(self, claim: str, context: str) -> Hallucination | None:
+        """Check if a claim is a hallucination.
+
+        Args:
+            claim: The claim to check.
+            context: The context to verify against.
+
+        Returns:
+            Hallucination object if the claim is a hallucination, None otherwise.
+
+        Raises:
+            EvaluationError: If verification fails.
+        """
+        prompt = HALLUCINATION_DETECTION_PROMPT.format(claim=claim, context=context)
+
+        try:
+            llm_response = await self.llm.generate(prompt)
+            result = self._parse_json_object(llm_response)
+
+            is_hallucination = bool(result.get("is_hallucination", False))
+            reason = str(result.get("reason", "No reason provided."))
+
+            if is_hallucination:
+                return Hallucination(claim=claim, reason=reason)
+            return None
+        except Exception as e:
+            msg = f"Failed to check hallucination for claim '{claim}': {e}"
+            raise EvaluationError(msg) from e
+
+    def _parse_json_array(self, text: str) -> list[str]:
+        """Parse a JSON array from LLM response.
+
+        Args:
+            text: The LLM response text.
+
+        Returns:
+            Parsed list of strings.
+        """
+        text = text.strip()
+
+        # Try direct parse first
+        try:
+            result = json.loads(text)
+            if isinstance(result, list):
+                return result
+        except json.JSONDecodeError:
+            pass
+
+        # Try to extract JSON array from text
+        match = re.search(r"\[.*\]", text, re.DOTALL)
+        if match:
+            try:
+                result = json.loads(match.group())
+                if isinstance(result, list):
+                    return result
+            except json.JSONDecodeError:
+                pass
+
+        return []
+
+    def _parse_json_object(self, text: str) -> dict[str, object]:
+        """Parse a JSON object from LLM response.
+
+        Args:
+            text: The LLM response text.
+
+        Returns:
+            Parsed dictionary.
+        """
+        text = text.strip()
+
+        # Try direct parse first
+        try:
+            result = json.loads(text)
+            if isinstance(result, dict):
+                return result
+        except json.JSONDecodeError:
+            pass
+
+        # Try to extract JSON object from text
+        match = re.search(r"\{.*\}", text, re.DOTALL)
+        if match:
+            try:
+                result = json.loads(match.group())
+                if isinstance(result, dict):
+                    return result
+            except json.JSONDecodeError:
+                pass
+
+        return {}

--- a/tests/unit/test_hallucination.py
+++ b/tests/unit/test_hallucination.py
@@ -1,0 +1,466 @@
+"""Tests for Hallucination detector."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ragnarok_ai.core.exceptions import EvaluationError
+from ragnarok_ai.evaluators.hallucination import (
+    Hallucination,
+    HallucinationDetector,
+    HallucinationResult,
+)
+
+
+class TestHallucinationDetectorInit:
+    """Tests for HallucinationDetector initialization."""
+
+    def test_init_with_llm(self) -> None:
+        """Detector stores the LLM reference."""
+        mock_llm = AsyncMock()
+        detector = HallucinationDetector(llm=mock_llm)
+
+        assert detector.llm is mock_llm
+
+
+class TestHallucinationDetectorEvaluate:
+    """Tests for HallucinationDetector.evaluate method."""
+
+    @pytest.mark.asyncio
+    async def test_evaluate_no_hallucinations(self) -> None:
+        """Returns 0.0 when no hallucinations are detected."""
+        mock_llm = AsyncMock()
+        mock_llm.generate.side_effect = [
+            '["Paris is the capital of France"]',
+            '{"is_hallucination": false, "reason": "Supported by context."}',
+        ]
+
+        detector = HallucinationDetector(llm=mock_llm)
+        score = await detector.evaluate(
+            response="Paris is the capital of France.",
+            context="France is a country in Europe. Its capital is Paris.",
+        )
+
+        assert score == 0.0
+
+    @pytest.mark.asyncio
+    async def test_evaluate_all_hallucinations(self) -> None:
+        """Returns 1.0 when all claims are hallucinations."""
+        mock_llm = AsyncMock()
+        mock_llm.generate.side_effect = [
+            '["Paris was founded in 500 BC"]',
+            '{"is_hallucination": true, "reason": "Not mentioned in context."}',
+        ]
+
+        detector = HallucinationDetector(llm=mock_llm)
+        score = await detector.evaluate(
+            response="Paris was founded in 500 BC.",
+            context="France is a country in Europe. Its capital is Paris.",
+        )
+
+        assert score == 1.0
+
+    @pytest.mark.asyncio
+    async def test_evaluate_partial_hallucinations(self) -> None:
+        """Returns partial score when some claims are hallucinations."""
+        mock_llm = AsyncMock()
+        mock_llm.generate.side_effect = [
+            '["Paris is the capital of France", "Paris was founded in 500 BC"]',
+            '{"is_hallucination": false, "reason": "Supported by context."}',
+            '{"is_hallucination": true, "reason": "Not mentioned in context."}',
+        ]
+
+        detector = HallucinationDetector(llm=mock_llm)
+        score = await detector.evaluate(
+            response="Paris is the capital of France. Paris was founded in 500 BC.",
+            context="France is a country in Europe. Its capital is Paris.",
+        )
+
+        assert score == 0.5
+
+    @pytest.mark.asyncio
+    async def test_evaluate_empty_response(self) -> None:
+        """Returns 0.0 for empty response (no claims to hallucinate)."""
+        mock_llm = AsyncMock()
+
+        detector = HallucinationDetector(llm=mock_llm)
+        score = await detector.evaluate(
+            response="",
+            context="Some context here.",
+        )
+
+        assert score == 0.0
+        mock_llm.generate.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_evaluate_empty_context(self) -> None:
+        """Returns 1.0 for empty context (all claims are potential hallucinations)."""
+        mock_llm = AsyncMock()
+
+        detector = HallucinationDetector(llm=mock_llm)
+        score = await detector.evaluate(
+            response="Paris is the capital.",
+            context="",
+        )
+
+        assert score == 1.0
+        mock_llm.generate.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_evaluate_no_claims_extracted(self) -> None:
+        """Returns 0.0 when no claims can be extracted."""
+        mock_llm = AsyncMock()
+        mock_llm.generate.return_value = "[]"
+
+        detector = HallucinationDetector(llm=mock_llm)
+        score = await detector.evaluate(
+            response="Hello!",
+            context="Some context.",
+        )
+
+        assert score == 0.0
+
+    @pytest.mark.asyncio
+    async def test_evaluate_query_parameter_ignored(self) -> None:
+        """Query parameter is accepted but not used."""
+        mock_llm = AsyncMock()
+        mock_llm.generate.side_effect = [
+            '["Paris is the capital"]',
+            '{"is_hallucination": false, "reason": "Confirmed."}',
+        ]
+
+        detector = HallucinationDetector(llm=mock_llm)
+        score = await detector.evaluate(
+            response="Paris is the capital.",
+            context="Its capital is Paris.",
+            query="What is the capital?",
+        )
+
+        assert score == 0.0
+
+
+class TestHallucinationDetectorEvaluateDetailed:
+    """Tests for HallucinationDetector.evaluate_detailed method."""
+
+    @pytest.mark.asyncio
+    async def test_evaluate_detailed_returns_result(self) -> None:
+        """Returns HallucinationResult with hallucinations list and reasoning."""
+        mock_llm = AsyncMock()
+        mock_llm.generate.side_effect = [
+            '["Paris is the capital", "Founded in 500 BC"]',
+            '{"is_hallucination": false, "reason": "Confirmed."}',
+            '{"is_hallucination": true, "reason": "Not in context."}',
+        ]
+
+        detector = HallucinationDetector(llm=mock_llm)
+        result = await detector.evaluate_detailed(
+            response="Paris is the capital. Founded in 500 BC.",
+            context="France is a country. Its capital is Paris.",
+        )
+
+        assert isinstance(result, HallucinationResult)
+        assert result.score == 0.5
+        assert result.total_claims == 2
+        assert len(result.hallucinations) == 1
+        assert result.hallucinations[0].claim == "Founded in 500 BC"
+        assert "Not in context" in result.hallucinations[0].reason
+        assert "1 out of 2" in result.reasoning
+
+    @pytest.mark.asyncio
+    async def test_evaluate_detailed_no_hallucinations(self) -> None:
+        """No hallucinations returns appropriate result."""
+        mock_llm = AsyncMock()
+        mock_llm.generate.side_effect = [
+            '["Claim 1", "Claim 2"]',
+            '{"is_hallucination": false, "reason": "OK"}',
+            '{"is_hallucination": false, "reason": "OK"}',
+        ]
+
+        detector = HallucinationDetector(llm=mock_llm)
+        result = await detector.evaluate_detailed(
+            response="Response with claims.",
+            context="Supporting context.",
+        )
+
+        assert result.score == 0.0
+        assert result.hallucinations == []
+        assert result.total_claims == 2
+        assert "No hallucinations" in result.reasoning
+
+    @pytest.mark.asyncio
+    async def test_evaluate_detailed_all_hallucinations(self) -> None:
+        """All hallucinations returns appropriate result."""
+        mock_llm = AsyncMock()
+        mock_llm.generate.side_effect = [
+            '["False claim 1", "False claim 2"]',
+            '{"is_hallucination": true, "reason": "Made up"}',
+            '{"is_hallucination": true, "reason": "Fabricated"}',
+        ]
+
+        detector = HallucinationDetector(llm=mock_llm)
+        result = await detector.evaluate_detailed(
+            response="False claims here.",
+            context="Unrelated context.",
+        )
+
+        assert result.score == 1.0
+        assert len(result.hallucinations) == 2
+        assert result.total_claims == 2
+        assert "All claims" in result.reasoning
+
+    @pytest.mark.asyncio
+    async def test_evaluate_detailed_empty_response(self) -> None:
+        """Empty response returns appropriate result."""
+        mock_llm = AsyncMock()
+
+        detector = HallucinationDetector(llm=mock_llm)
+        result = await detector.evaluate_detailed(
+            response="   ",
+            context="Some context.",
+        )
+
+        assert result.score == 0.0
+        assert result.hallucinations == []
+        assert result.total_claims == 0
+        assert "Empty response" in result.reasoning
+
+    @pytest.mark.asyncio
+    async def test_evaluate_detailed_empty_context(self) -> None:
+        """Empty context returns appropriate result."""
+        mock_llm = AsyncMock()
+
+        detector = HallucinationDetector(llm=mock_llm)
+        result = await detector.evaluate_detailed(
+            response="Some response.",
+            context="   ",
+        )
+
+        assert result.score == 1.0
+        assert result.hallucinations == []
+        assert result.total_claims == 0
+        assert "No context provided" in result.reasoning
+
+    @pytest.mark.asyncio
+    async def test_evaluate_detailed_no_claims(self) -> None:
+        """No claims returns appropriate result."""
+        mock_llm = AsyncMock()
+        mock_llm.generate.return_value = "[]"
+
+        detector = HallucinationDetector(llm=mock_llm)
+        result = await detector.evaluate_detailed(
+            response="Hello there!",
+            context="Some context.",
+        )
+
+        assert result.score == 0.0
+        assert result.hallucinations == []
+        assert result.total_claims == 0
+        assert "No verifiable claims" in result.reasoning
+
+
+class TestHallucinationDetectorClaimExtraction:
+    """Tests for claim extraction logic."""
+
+    @pytest.mark.asyncio
+    async def test_extract_claims_json_array(self) -> None:
+        """Extracts claims from valid JSON array."""
+        mock_llm = AsyncMock()
+        mock_llm.generate.side_effect = [
+            '["Claim A", "Claim B"]',
+            '{"is_hallucination": false, "reason": "OK"}',
+            '{"is_hallucination": false, "reason": "OK"}',
+        ]
+
+        detector = HallucinationDetector(llm=mock_llm)
+        result = await detector.evaluate_detailed("Response", "Context")
+
+        assert result.total_claims == 2
+
+    @pytest.mark.asyncio
+    async def test_extract_claims_with_surrounding_text(self) -> None:
+        """Extracts claims from JSON array embedded in text."""
+        mock_llm = AsyncMock()
+        mock_llm.generate.side_effect = [
+            'Here are the claims: ["Claim X"] and that\'s it.',
+            '{"is_hallucination": false, "reason": "Found."}',
+        ]
+
+        detector = HallucinationDetector(llm=mock_llm)
+        result = await detector.evaluate_detailed("Response", "Context")
+
+        assert result.total_claims == 1
+
+    @pytest.mark.asyncio
+    async def test_extract_claims_llm_error(self) -> None:
+        """Raises EvaluationError on LLM failure."""
+        mock_llm = AsyncMock()
+        mock_llm.generate.side_effect = Exception("LLM error")
+
+        detector = HallucinationDetector(llm=mock_llm)
+
+        with pytest.raises(EvaluationError, match="Failed to extract claims"):
+            await detector.evaluate_detailed("Response", "Context")
+
+
+class TestHallucinationDetectorHallucinationCheck:
+    """Tests for hallucination checking logic."""
+
+    @pytest.mark.asyncio
+    async def test_check_hallucination_detected(self) -> None:
+        """Correctly identifies hallucination."""
+        mock_llm = AsyncMock()
+        mock_llm.generate.side_effect = [
+            '["Made up fact"]',
+            '{"is_hallucination": true, "reason": "Not in context."}',
+        ]
+
+        detector = HallucinationDetector(llm=mock_llm)
+        result = await detector.evaluate_detailed("Made up fact.", "Real context.")
+
+        assert len(result.hallucinations) == 1
+        assert result.hallucinations[0].claim == "Made up fact"
+
+    @pytest.mark.asyncio
+    async def test_check_hallucination_not_detected(self) -> None:
+        """Correctly identifies supported claim."""
+        mock_llm = AsyncMock()
+        mock_llm.generate.side_effect = [
+            '["True fact"]',
+            '{"is_hallucination": false, "reason": "Supported."}',
+        ]
+
+        detector = HallucinationDetector(llm=mock_llm)
+        result = await detector.evaluate_detailed("True fact.", "Context with true fact.")
+
+        assert len(result.hallucinations) == 0
+
+    @pytest.mark.asyncio
+    async def test_check_hallucination_json_with_text(self) -> None:
+        """Parses hallucination check result with surrounding text."""
+        mock_llm = AsyncMock()
+        mock_llm.generate.side_effect = [
+            '["Claim"]',
+            'Based on analysis: {"is_hallucination": true, "reason": "Fabricated."}',
+        ]
+
+        detector = HallucinationDetector(llm=mock_llm)
+        result = await detector.evaluate_detailed("Response", "Context")
+
+        assert len(result.hallucinations) == 1
+
+    @pytest.mark.asyncio
+    async def test_check_hallucination_llm_error(self) -> None:
+        """Raises EvaluationError on verification failure."""
+        mock_llm = AsyncMock()
+        mock_llm.generate.side_effect = [
+            '["Claim"]',
+            Exception("Verification failed"),
+        ]
+
+        detector = HallucinationDetector(llm=mock_llm)
+
+        with pytest.raises(EvaluationError, match="Failed to check hallucination"):
+            await detector.evaluate_detailed("Response", "Context")
+
+
+class TestHallucinationDetectorProtocolCompliance:
+    """Tests for EvaluatorProtocol compliance."""
+
+    def test_implements_protocol(self) -> None:
+        """HallucinationDetector implements EvaluatorProtocol."""
+        from ragnarok_ai.core.protocols import EvaluatorProtocol
+
+        mock_llm = AsyncMock()
+        detector = HallucinationDetector(llm=mock_llm)
+
+        assert isinstance(detector, EvaluatorProtocol)
+
+    def test_has_evaluate_method(self) -> None:
+        """HallucinationDetector has evaluate method."""
+        mock_llm = AsyncMock()
+        detector = HallucinationDetector(llm=mock_llm)
+
+        assert hasattr(detector, "evaluate")
+        assert callable(detector.evaluate)
+
+
+class TestHallucinationModel:
+    """Tests for Hallucination model."""
+
+    def test_create_hallucination(self) -> None:
+        """Hallucination can be created with valid data."""
+        hallucination = Hallucination(
+            claim="Made up claim",
+            reason="Not in context",
+        )
+
+        assert hallucination.claim == "Made up claim"
+        assert hallucination.reason == "Not in context"
+
+    def test_hallucination_is_frozen(self) -> None:
+        """Hallucination is immutable."""
+        from pydantic import ValidationError
+
+        hallucination = Hallucination(
+            claim="Test",
+            reason="Reason",
+        )
+
+        with pytest.raises(ValidationError):
+            hallucination.claim = "New claim"
+
+
+class TestHallucinationResultModel:
+    """Tests for HallucinationResult model."""
+
+    def test_create_hallucination_result(self) -> None:
+        """HallucinationResult can be created with valid data."""
+        result = HallucinationResult(
+            score=0.25,
+            hallucinations=[],
+            total_claims=4,
+            reasoning="Test reasoning",
+        )
+
+        assert result.score == 0.25
+        assert result.hallucinations == []
+        assert result.total_claims == 4
+        assert result.reasoning == "Test reasoning"
+
+    def test_create_with_defaults(self) -> None:
+        """HallucinationResult uses defaults for optional fields."""
+        result = HallucinationResult(
+            score=0.5,
+            reasoning="OK",
+        )
+
+        assert result.hallucinations == []
+        assert result.total_claims == 0
+
+    def test_score_validation(self) -> None:
+        """Score must be between 0 and 1."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            HallucinationResult(score=1.5, reasoning="Invalid")
+
+        with pytest.raises(ValidationError):
+            HallucinationResult(score=-0.1, reasoning="Invalid")
+
+    def test_total_claims_validation(self) -> None:
+        """Total claims must be non-negative."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            HallucinationResult(score=0.5, total_claims=-1, reasoning="Invalid")
+
+    def test_hallucination_result_is_frozen(self) -> None:
+        """HallucinationResult is immutable."""
+        from pydantic import ValidationError
+
+        result = HallucinationResult(score=0.0, reasoning="OK")
+
+        with pytest.raises(ValidationError):
+            result.score = 0.5


### PR DESCRIPTION
## Summary

- Add `HallucinationDetector` with LLM-as-judge approach
- Score from 0 (no hallucination) to 1 (all hallucinations)
- Returns list of detected hallucinations with explanations
- 30 unit tests with mocked LLM

Closes #4