### PR TITLE
feat(core): add intelligent CI gating - Completes v0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ metrics.log_to("./metrics/")  # Time-series storage
 - [x] Relevance evaluator
 - [x] Hallucination detection
 - [x] HTML report with drill-down (failed questions, retrieved chunks)
-- [ ] Intelligent CI gating (stable metrics fail, LLM judgments warn)
+- [x] Intelligent CI gating (stable metrics fail, LLM judgments warn)
 
 ### v0.3 — Test Generation & Golden Sets
 - [ ] Synthetic question generation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
 dependencies = [
     "pydantic>=2.0",
     "pydantic-settings>=2.0",
+    "pyyaml>=6.0",
 ]
 
 [project.optional-dependencies]
@@ -35,6 +36,7 @@ dev = [
     "respx>=0.20",
     "httpx>=0.27",
     "pip-audit>=2.7",
+    "types-pyyaml>=6.0",
 ]
 ollama = [
     "httpx>=0.27",
@@ -130,6 +132,10 @@ disallow_untyped_defs = false
 
 [[tool.mypy.overrides]]
 module = ["qdrant_client", "qdrant_client.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["yaml", "yaml.*"]
 ignore_missing_imports = true
 
 # ============================================================================

--- a/src/ragnarok_ai/core/__init__.py
+++ b/src/ragnarok_ai/core/__init__.py
@@ -13,6 +13,14 @@ from ragnarok_ai.core.exceptions import (
     LLMConnectionError,
     RagnarokError,
 )
+from ragnarok_ai.core.gating import (
+    GatingConfig,
+    GatingEvaluationResult,
+    GatingEvaluator,
+    GatingResult,
+    MetricCategory,
+    MetricResult,
+)
 from ragnarok_ai.core.protocols import (
     EvaluatorProtocol,
     LLMProtocol,
@@ -30,8 +38,14 @@ __all__ = [
     "Document",
     "EvaluationError",
     "EvaluatorProtocol",
+    "GatingConfig",
+    "GatingEvaluationResult",
+    "GatingEvaluator",
+    "GatingResult",
     "LLMConnectionError",
     "LLMProtocol",
+    "MetricCategory",
+    "MetricResult",
     "Query",
     "RagnarokError",
     "RetrievalResult",

--- a/src/ragnarok_ai/core/gating.py
+++ b/src/ragnarok_ai/core/gating.py
@@ -1,0 +1,304 @@
+"""CI gating configuration for ragnarok-ai.
+
+This module provides intelligent CI/CD gating that distinguishes
+between stable and unstable metrics.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class MetricCategory(str, Enum):
+    """Category of metric for gating purposes."""
+
+    STABLE = "stable"
+    UNSTABLE = "unstable"
+
+
+class GatingResult(str, Enum):
+    """Result of gating evaluation."""
+
+    PASS = "pass"
+    WARN = "warn"
+    FAIL = "fail"
+
+
+class MetricResult(BaseModel):
+    """Result for a single metric evaluation.
+
+    Attributes:
+        name: Name of the metric.
+        value: Actual value of the metric.
+        threshold: Threshold value for the metric.
+        category: Whether this is a stable or unstable metric.
+        result: Pass, warn, or fail result.
+    """
+
+    model_config = {"frozen": True}
+
+    name: str = Field(..., description="Metric name")
+    value: float = Field(..., description="Actual metric value")
+    threshold: float = Field(..., description="Threshold value")
+    category: MetricCategory = Field(..., description="Metric category")
+    result: GatingResult = Field(..., description="Evaluation result")
+
+
+class GatingConfig(BaseModel):
+    """Configuration for CI gating thresholds.
+
+    Attributes:
+        stable: Thresholds for stable metrics (hard fail if below).
+        unstable: Thresholds for unstable metrics (warning only if below).
+    """
+
+    model_config = {"frozen": True}
+
+    stable: dict[str, float] = Field(
+        default_factory=lambda: {
+            "precision": 0.8,
+            "recall": 0.8,
+            "mrr": 0.8,
+            "ndcg": 0.8,
+        },
+        description="Stable metric thresholds (fail if below)",
+    )
+    unstable: dict[str, float] = Field(
+        default_factory=lambda: {
+            "faithfulness": 0.7,
+            "relevance": 0.7,
+            "hallucination": 0.3,  # Lower is better for hallucination
+        },
+        description="Unstable metric thresholds (warn if below)",
+    )
+
+    @classmethod
+    def from_yaml(cls, path: Path | str) -> GatingConfig:
+        """Load gating configuration from a YAML file.
+
+        Args:
+            path: Path to the YAML configuration file.
+
+        Returns:
+            GatingConfig loaded from the file.
+
+        Raises:
+            FileNotFoundError: If the file doesn't exist.
+            ValueError: If the YAML is invalid.
+        """
+        import yaml
+
+        path = Path(path)
+        if not path.exists():
+            msg = f"Configuration file not found: {path}"
+            raise FileNotFoundError(msg)
+
+        content = path.read_text()
+        data = yaml.safe_load(content)
+
+        if data is None:
+            return cls()
+
+        gating_data = data.get("gating", data)
+        return cls(
+            stable=gating_data.get("stable", {}),
+            unstable=gating_data.get("unstable", {}),
+        )
+
+    def to_yaml(self, path: Path | str) -> None:
+        """Save gating configuration to a YAML file.
+
+        Args:
+            path: Path to the output YAML file.
+        """
+        import yaml
+
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        data = {
+            "gating": {
+                "stable": dict(self.stable),
+                "unstable": dict(self.unstable),
+            }
+        }
+
+        path.write_text(yaml.dump(data, default_flow_style=False, sort_keys=False))
+
+
+class GatingEvaluationResult(BaseModel):
+    """Result of evaluating metrics against gating thresholds.
+
+    Attributes:
+        overall_result: The overall gating result (pass/warn/fail).
+        exit_code: Exit code for CI (0=pass, 1=fail, 2=warn).
+        metrics: Individual metric results.
+        summary: Human-readable summary of the evaluation.
+    """
+
+    model_config = {"frozen": True}
+
+    overall_result: GatingResult = Field(..., description="Overall result")
+    exit_code: int = Field(..., ge=0, le=2, description="Exit code for CI")
+    metrics: list[MetricResult] = Field(default_factory=list, description="Metric results")
+    summary: str = Field(..., description="Human-readable summary")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON output.
+
+        Returns:
+            Dictionary representation of the result.
+        """
+        return {
+            "overall_result": self.overall_result.value,
+            "exit_code": self.exit_code,
+            "metrics": [
+                {
+                    "name": m.name,
+                    "value": m.value,
+                    "threshold": m.threshold,
+                    "category": m.category.value,
+                    "result": m.result.value,
+                }
+                for m in self.metrics
+            ],
+            "summary": self.summary,
+        }
+
+
+class GatingEvaluator:
+    """Evaluates metrics against gating thresholds.
+
+    This evaluator distinguishes between stable and unstable metrics:
+    - Stable metrics (retrieval, latency): Hard fail if below threshold
+    - Unstable metrics (LLM-as-judge): Warning only if below threshold
+
+    Exit codes:
+    - 0: All metrics pass
+    - 1: At least one stable metric failed
+    - 2: Only unstable metrics below threshold (warning)
+
+    Attributes:
+        config: The gating configuration.
+
+    Example:
+        >>> config = GatingConfig()
+        >>> evaluator = GatingEvaluator(config)
+        >>> result = evaluator.evaluate({"precision": 0.85, "faithfulness": 0.65})
+        >>> print(result.exit_code)  # 2 (warning - faithfulness below threshold)
+    """
+
+    def __init__(self, config: GatingConfig | None = None) -> None:
+        """Initialize GatingEvaluator.
+
+        Args:
+            config: Gating configuration. Uses defaults if not provided.
+        """
+        self.config = config or GatingConfig()
+
+    def evaluate(self, metrics: dict[str, float]) -> GatingEvaluationResult:
+        """Evaluate metrics against gating thresholds.
+
+        Args:
+            metrics: Dictionary of metric names to values.
+
+        Returns:
+            GatingEvaluationResult with overall result and per-metric details.
+        """
+        results: list[MetricResult] = []
+        has_stable_fail = False
+        has_unstable_warn = False
+
+        # Check stable metrics
+        for name, threshold in self.config.stable.items():
+            if name in metrics:
+                value = metrics[name]
+                passed = value >= threshold
+                result = GatingResult.PASS if passed else GatingResult.FAIL
+
+                if not passed:
+                    has_stable_fail = True
+
+                results.append(
+                    MetricResult(
+                        name=name,
+                        value=value,
+                        threshold=threshold,
+                        category=MetricCategory.STABLE,
+                        result=result,
+                    )
+                )
+
+        # Check unstable metrics
+        for name, threshold in self.config.unstable.items():
+            if name in metrics:
+                value = metrics[name]
+
+                # For hallucination, lower is better
+                passed = value <= threshold if name == "hallucination" else value >= threshold
+
+                result = GatingResult.PASS if passed else GatingResult.WARN
+
+                if not passed:
+                    has_unstable_warn = True
+
+                results.append(
+                    MetricResult(
+                        name=name,
+                        value=value,
+                        threshold=threshold,
+                        category=MetricCategory.UNSTABLE,
+                        result=result,
+                    )
+                )
+
+        # Determine overall result and exit code
+        if has_stable_fail:
+            overall_result = GatingResult.FAIL
+            exit_code = 1
+            summary = self._generate_fail_summary(results)
+        elif has_unstable_warn:
+            overall_result = GatingResult.WARN
+            exit_code = 2
+            summary = self._generate_warn_summary(results)
+        else:
+            overall_result = GatingResult.PASS
+            exit_code = 0
+            summary = "All metrics passed gating thresholds."
+
+        return GatingEvaluationResult(
+            overall_result=overall_result,
+            exit_code=exit_code,
+            metrics=results,
+            summary=summary,
+        )
+
+    def _generate_fail_summary(self, results: list[MetricResult]) -> str:
+        """Generate summary for failed gating.
+
+        Args:
+            results: List of metric results.
+
+        Returns:
+            Human-readable summary.
+        """
+        failed = [r for r in results if r.result == GatingResult.FAIL]
+        failed_names = ", ".join(r.name for r in failed)
+        return f"Gating FAILED: Stable metrics below threshold: {failed_names}"
+
+    def _generate_warn_summary(self, results: list[MetricResult]) -> str:
+        """Generate summary for warning gating.
+
+        Args:
+            results: List of metric results.
+
+        Returns:
+            Human-readable summary.
+        """
+        warned = [r for r in results if r.result == GatingResult.WARN]
+        warned_names = ", ".join(r.name for r in warned)
+        return f"Gating WARNING: Unstable metrics below threshold: {warned_names}"

--- a/tests/unit/test_gating.py
+++ b/tests/unit/test_gating.py
@@ -1,0 +1,414 @@
+"""Tests for CI gating module."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from ragnarok_ai.core.gating import (
+    GatingConfig,
+    GatingEvaluationResult,
+    GatingEvaluator,
+    GatingResult,
+    MetricCategory,
+    MetricResult,
+)
+
+
+class TestGatingConfigDefaults:
+    """Tests for GatingConfig default values."""
+
+    def test_default_stable_thresholds(self) -> None:
+        """Default stable thresholds are set."""
+        config = GatingConfig()
+
+        assert config.stable["precision"] == 0.8
+        assert config.stable["recall"] == 0.8
+        assert config.stable["mrr"] == 0.8
+        assert config.stable["ndcg"] == 0.8
+
+    def test_default_unstable_thresholds(self) -> None:
+        """Default unstable thresholds are set."""
+        config = GatingConfig()
+
+        assert config.unstable["faithfulness"] == 0.7
+        assert config.unstable["relevance"] == 0.7
+        assert config.unstable["hallucination"] == 0.3
+
+    def test_custom_thresholds(self) -> None:
+        """Custom thresholds override defaults."""
+        config = GatingConfig(
+            stable={"precision": 0.9},
+            unstable={"faithfulness": 0.8},
+        )
+
+        assert config.stable["precision"] == 0.9
+        assert config.unstable["faithfulness"] == 0.8
+
+
+class TestGatingConfigYaml:
+    """Tests for GatingConfig YAML serialization."""
+
+    def test_from_yaml_full_config(self, tmp_path: Path) -> None:
+        """Loads full config from YAML."""
+        yaml_content = """
+gating:
+  stable:
+    precision: 0.85
+    recall: 0.75
+  unstable:
+    faithfulness: 0.65
+"""
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(yaml_content)
+
+        config = GatingConfig.from_yaml(config_file)
+
+        assert config.stable["precision"] == 0.85
+        assert config.stable["recall"] == 0.75
+        assert config.unstable["faithfulness"] == 0.65
+
+    def test_from_yaml_partial_config(self, tmp_path: Path) -> None:
+        """Loads partial config from YAML."""
+        yaml_content = """
+gating:
+  stable:
+    precision: 0.9
+"""
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(yaml_content)
+
+        config = GatingConfig.from_yaml(config_file)
+
+        assert config.stable["precision"] == 0.9
+        assert config.unstable == {}
+
+    def test_from_yaml_empty_file(self, tmp_path: Path) -> None:
+        """Handles empty YAML file."""
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("")
+
+        config = GatingConfig.from_yaml(config_file)
+
+        # Should use defaults
+        assert config.stable["precision"] == 0.8
+
+    def test_from_yaml_file_not_found(self, tmp_path: Path) -> None:
+        """Raises FileNotFoundError for missing file."""
+        import pytest
+
+        with pytest.raises(FileNotFoundError):
+            GatingConfig.from_yaml(tmp_path / "missing.yaml")
+
+    def test_to_yaml(self, tmp_path: Path) -> None:
+        """Saves config to YAML."""
+        config = GatingConfig(
+            stable={"precision": 0.9},
+            unstable={"faithfulness": 0.8},
+        )
+        output_path = tmp_path / "output.yaml"
+
+        config.to_yaml(output_path)
+
+        assert output_path.exists()
+        content = output_path.read_text()
+        assert "precision" in content
+        assert "0.9" in content
+
+    def test_to_yaml_creates_directories(self, tmp_path: Path) -> None:
+        """Creates parent directories if needed."""
+        config = GatingConfig()
+        output_path = tmp_path / "nested" / "dir" / "config.yaml"
+
+        config.to_yaml(output_path)
+
+        assert output_path.exists()
+
+
+class TestGatingEvaluatorAllPass:
+    """Tests for when all metrics pass."""
+
+    def test_all_stable_pass(self) -> None:
+        """All stable metrics pass returns exit code 0."""
+        evaluator = GatingEvaluator()
+        metrics = {
+            "precision": 0.85,
+            "recall": 0.82,
+            "mrr": 0.88,
+            "ndcg": 0.84,
+        }
+
+        result = evaluator.evaluate(metrics)
+
+        assert result.overall_result == GatingResult.PASS
+        assert result.exit_code == 0
+        assert "All metrics passed" in result.summary
+
+    def test_all_unstable_pass(self) -> None:
+        """All unstable metrics pass returns exit code 0."""
+        evaluator = GatingEvaluator()
+        metrics = {
+            "faithfulness": 0.75,
+            "relevance": 0.78,
+            "hallucination": 0.15,  # Lower is better
+        }
+
+        result = evaluator.evaluate(metrics)
+
+        assert result.overall_result == GatingResult.PASS
+        assert result.exit_code == 0
+
+    def test_all_metrics_pass(self) -> None:
+        """All metrics pass returns exit code 0."""
+        evaluator = GatingEvaluator()
+        metrics = {
+            "precision": 0.85,
+            "recall": 0.82,
+            "faithfulness": 0.75,
+            "hallucination": 0.1,
+        }
+
+        result = evaluator.evaluate(metrics)
+
+        assert result.overall_result == GatingResult.PASS
+        assert result.exit_code == 0
+
+
+class TestGatingEvaluatorStableFail:
+    """Tests for when stable metrics fail."""
+
+    def test_stable_metric_fails(self) -> None:
+        """Stable metric failure returns exit code 1."""
+        evaluator = GatingEvaluator()
+        metrics = {
+            "precision": 0.5,  # Below 0.8 threshold
+            "recall": 0.85,
+        }
+
+        result = evaluator.evaluate(metrics)
+
+        assert result.overall_result == GatingResult.FAIL
+        assert result.exit_code == 1
+        assert "FAILED" in result.summary
+        assert "precision" in result.summary
+
+    def test_multiple_stable_fail(self) -> None:
+        """Multiple stable failures returns exit code 1."""
+        evaluator = GatingEvaluator()
+        metrics = {
+            "precision": 0.5,
+            "recall": 0.4,
+            "mrr": 0.3,
+        }
+
+        result = evaluator.evaluate(metrics)
+
+        assert result.overall_result == GatingResult.FAIL
+        assert result.exit_code == 1
+
+    def test_stable_fail_overrides_unstable_warn(self) -> None:
+        """Stable fail takes precedence over unstable warning."""
+        evaluator = GatingEvaluator()
+        metrics = {
+            "precision": 0.5,  # Stable fail
+            "faithfulness": 0.5,  # Unstable warn
+        }
+
+        result = evaluator.evaluate(metrics)
+
+        assert result.overall_result == GatingResult.FAIL
+        assert result.exit_code == 1
+
+
+class TestGatingEvaluatorUnstableWarn:
+    """Tests for when only unstable metrics fail."""
+
+    def test_unstable_metric_warns(self) -> None:
+        """Unstable metric failure returns exit code 2."""
+        evaluator = GatingEvaluator()
+        metrics = {
+            "precision": 0.85,  # Pass
+            "faithfulness": 0.5,  # Below 0.7 threshold
+        }
+
+        result = evaluator.evaluate(metrics)
+
+        assert result.overall_result == GatingResult.WARN
+        assert result.exit_code == 2
+        assert "WARNING" in result.summary
+        assert "faithfulness" in result.summary
+
+    def test_hallucination_higher_is_bad(self) -> None:
+        """Hallucination above threshold triggers warning."""
+        evaluator = GatingEvaluator()
+        metrics = {
+            "precision": 0.85,
+            "hallucination": 0.5,  # Above 0.3 threshold (bad)
+        }
+
+        result = evaluator.evaluate(metrics)
+
+        assert result.overall_result == GatingResult.WARN
+        assert result.exit_code == 2
+
+    def test_multiple_unstable_warn(self) -> None:
+        """Multiple unstable warnings returns exit code 2."""
+        evaluator = GatingEvaluator()
+        metrics = {
+            "faithfulness": 0.5,
+            "relevance": 0.4,
+        }
+
+        result = evaluator.evaluate(metrics)
+
+        assert result.overall_result == GatingResult.WARN
+        assert result.exit_code == 2
+
+
+class TestGatingEvaluatorCustomConfig:
+    """Tests with custom configuration."""
+
+    def test_custom_thresholds(self) -> None:
+        """Custom thresholds are respected."""
+        config = GatingConfig(
+            stable={"precision": 0.9},
+            unstable={"faithfulness": 0.8},
+        )
+        evaluator = GatingEvaluator(config)
+        metrics = {
+            "precision": 0.85,  # Below 0.9
+            "faithfulness": 0.75,  # Below 0.8
+        }
+
+        result = evaluator.evaluate(metrics)
+
+        assert result.overall_result == GatingResult.FAIL
+        assert result.exit_code == 1
+
+    def test_unknown_metrics_ignored(self) -> None:
+        """Metrics not in config are ignored."""
+        config = GatingConfig(
+            stable={"precision": 0.8},
+            unstable={},
+        )
+        evaluator = GatingEvaluator(config)
+        metrics = {
+            "precision": 0.85,
+            "unknown_metric": 0.1,
+        }
+
+        result = evaluator.evaluate(metrics)
+
+        assert result.overall_result == GatingResult.PASS
+        assert len(result.metrics) == 1
+
+
+class TestGatingEvaluatorMetricResults:
+    """Tests for individual metric results."""
+
+    def test_metric_results_populated(self) -> None:
+        """Metric results contain correct details."""
+        evaluator = GatingEvaluator()
+        metrics = {"precision": 0.85, "faithfulness": 0.5}
+
+        result = evaluator.evaluate(metrics)
+
+        assert len(result.metrics) == 2
+
+        precision_result = next(m for m in result.metrics if m.name == "precision")
+        assert precision_result.value == 0.85
+        assert precision_result.threshold == 0.8
+        assert precision_result.category == MetricCategory.STABLE
+        assert precision_result.result == GatingResult.PASS
+
+        faithfulness_result = next(m for m in result.metrics if m.name == "faithfulness")
+        assert faithfulness_result.value == 0.5
+        assert faithfulness_result.threshold == 0.7
+        assert faithfulness_result.category == MetricCategory.UNSTABLE
+        assert faithfulness_result.result == GatingResult.WARN
+
+
+class TestGatingEvaluationResultToDict:
+    """Tests for result serialization."""
+
+    def test_to_dict(self) -> None:
+        """Result can be converted to dictionary."""
+        result = GatingEvaluationResult(
+            overall_result=GatingResult.PASS,
+            exit_code=0,
+            metrics=[
+                MetricResult(
+                    name="precision",
+                    value=0.85,
+                    threshold=0.8,
+                    category=MetricCategory.STABLE,
+                    result=GatingResult.PASS,
+                )
+            ],
+            summary="All metrics passed.",
+        )
+
+        data = result.to_dict()
+
+        assert data["overall_result"] == "pass"
+        assert data["exit_code"] == 0
+        assert len(data["metrics"]) == 1
+        assert data["metrics"][0]["name"] == "precision"
+        assert data["metrics"][0]["category"] == "stable"
+
+
+class TestMetricResultModel:
+    """Tests for MetricResult model."""
+
+    def test_create_metric_result(self) -> None:
+        """MetricResult can be created with valid data."""
+        result = MetricResult(
+            name="precision",
+            value=0.85,
+            threshold=0.8,
+            category=MetricCategory.STABLE,
+            result=GatingResult.PASS,
+        )
+
+        assert result.name == "precision"
+        assert result.value == 0.85
+        assert result.threshold == 0.8
+        assert result.category == MetricCategory.STABLE
+        assert result.result == GatingResult.PASS
+
+    def test_metric_result_is_frozen(self) -> None:
+        """MetricResult is immutable."""
+        import pytest
+        from pydantic import ValidationError
+
+        result = MetricResult(
+            name="precision",
+            value=0.85,
+            threshold=0.8,
+            category=MetricCategory.STABLE,
+            result=GatingResult.PASS,
+        )
+
+        with pytest.raises(ValidationError):
+            result.value = 0.9
+
+
+class TestGatingResultEnum:
+    """Tests for GatingResult enum."""
+
+    def test_gating_result_values(self) -> None:
+        """GatingResult has correct values."""
+        assert GatingResult.PASS.value == "pass"
+        assert GatingResult.WARN.value == "warn"
+        assert GatingResult.FAIL.value == "fail"
+
+
+class TestMetricCategoryEnum:
+    """Tests for MetricCategory enum."""
+
+    def test_metric_category_values(self) -> None:
+        """MetricCategory has correct values."""
+        assert MetricCategory.STABLE.value == "stable"
+        assert MetricCategory.UNSTABLE.value == "unstable"

--- a/uv.lock
+++ b/uv.lock
@@ -2332,6 +2332,7 @@ source = { editable = "." }
 dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pyyaml" },
 ]
 
 [package.optional-dependencies]
@@ -2355,6 +2356,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "respx" },
     { name = "ruff" },
+    { name = "types-pyyaml" },
 ]
 langchain = [
     { name = "langchain" },
@@ -2381,11 +2383,13 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "qdrant-client", marker = "extra == 'qdrant'", specifier = ">=1.7" },
     { name = "ragnarok-ai", extras = ["ollama", "qdrant", "langchain", "cli"], marker = "extra == 'all'" },
     { name = "respx", marker = "extra == 'dev'", specifier = ">=0.20" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.3" },
     { name = "typer", marker = "extra == 'cli'", specifier = ">=0.9" },
+    { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
 ]
 provides-extras = ["dev", "ollama", "qdrant", "langchain", "cli", "all"]
 
@@ -2626,6 +2630,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/36/bf/8825b5929afd84d0dabd606c67cd57b8388cb3ec385f7ef19c5cc2202069/typer-0.21.1.tar.gz", hash = "sha256:ea835607cd752343b6b2b7ce676893e5a0324082268b48f27aa058bdb7d2145d", size = 110371 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/1d/d9257dd49ff2ca23ea5f132edf1281a0c4f9de8a762b9ae399b670a59235/typer-0.21.1-py3-none-any.whl", hash = "sha256:7985e89081c636b88d172c2ee0cfe33c253160994d47bdfdc302defd7d1f1d01", size = 47381 },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20250915"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/69/3c51b36d04da19b92f9e815be12753125bd8bc247ba0470a982e6979e71c/types_pyyaml-6.0.12.20250915.tar.gz", hash = "sha256:0f8b54a528c303f0e6f7165687dd33fafa81c807fcac23f632b63aa624ced1d3", size = 17522 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/e0/1eed384f02555dde685fff1a1ac805c1c7dcb6dd019c916fe659b1c1f9ec/types_pyyaml-6.0.12.20250915-py3-none-any.whl", hash = "sha256:e7d4d9e064e89a3b3cae120b4990cd370874d2bf12fa5f46c97018dd5d3c9ab6", size = 20338 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- `GatingConfig` with stable/unstable metric thresholds
- `GatingEvaluator` with exit codes: 0 (pass), 1 (fail), 2 (warn)
- Stable metrics (retrieval) fail build, unstable (LLM) warn only
- YAML configuration support
- 26 unit tests

Closes #6

---

**This completes the v0.2 milestone (Generation Metrics & Reporting):**
- [x] Qdrant adapter
- [x] Faithfulness evaluator
- [x] Relevance evaluator
- [x] Hallucination detection
- [x] HTML report with drill-down
- [x] Intelligent CI gating