### PR TITLE
feat(generators): adversarial question generation (#9)

### DIFF
--- a/src/ragnarok_ai/generators/__init__.py
+++ b/src/ragnarok_ai/generators/__init__.py
@@ -6,6 +6,13 @@ including synthetic question generation from documents.
 
 from __future__ import annotations
 
+from ragnarok_ai.generators.adversarial import (
+    AdversarialConfig,
+    AdversarialQuestion,
+    AdversarialQuestionGenerator,
+    AdversarialType,
+    ExpectedBehavior,
+)
 from ragnarok_ai.generators.base import QuestionGeneratorProtocol
 from ragnarok_ai.generators.io import load_testset, save_testset
 from ragnarok_ai.generators.models import GeneratedQuestion, GenerationConfig
@@ -22,7 +29,12 @@ from ragnarok_ai.generators.validators import QuestionValidator
 TestSetGenerator = SyntheticQuestionGenerator
 
 __all__ = [
+    "AdversarialConfig",
+    "AdversarialQuestion",
+    "AdversarialQuestionGenerator",
+    "AdversarialType",
     "DocumentRelationship",
+    "ExpectedBehavior",
     "GeneratedQuestion",
     "GenerationConfig",
     "MultiHopConfig",

--- a/src/ragnarok_ai/generators/adversarial.py
+++ b/src/ragnarok_ai/generators/adversarial.py
@@ -1,0 +1,359 @@
+"""Adversarial question generator for ragnarok-ai.
+
+This module provides adversarial question generation designed to expose
+RAG weaknesses through various types of challenging questions.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+
+from ragnarok_ai.core.types import Query, TestSet
+from ragnarok_ai.generators.parsing import parse_json_array
+
+if TYPE_CHECKING:
+    from ragnarok_ai.core.protocols import LLMProtocol
+    from ragnarok_ai.core.types import Document
+
+
+class AdversarialType(str, Enum):
+    """Types of adversarial questions."""
+
+    OUT_OF_SCOPE = "out_of_scope"
+    AMBIGUOUS = "ambiguous"
+    MISLEADING = "misleading"
+    BOUNDARY = "boundary"
+
+
+class ExpectedBehavior(str, Enum):
+    """Expected RAG system behavior for adversarial questions."""
+
+    REFUSE = "refuse"  # Should say "I don't know" or refuse to answer
+    CLARIFY = "clarify"  # Should ask for clarification
+    CORRECT = "correct"  # Should correct the false premise
+    HANDLE_GRACEFULLY = "handle_gracefully"  # Should not crash or error
+
+
+# Mapping of adversarial types to expected behaviors
+ADVERSARIAL_EXPECTED_BEHAVIOR: dict[AdversarialType, ExpectedBehavior] = {
+    AdversarialType.OUT_OF_SCOPE: ExpectedBehavior.REFUSE,
+    AdversarialType.AMBIGUOUS: ExpectedBehavior.CLARIFY,
+    AdversarialType.MISLEADING: ExpectedBehavior.CORRECT,
+    AdversarialType.BOUNDARY: ExpectedBehavior.HANDLE_GRACEFULLY,
+}
+
+
+# Prompt for generating out-of-scope questions
+OUT_OF_SCOPE_PROMPT = """You are an expert at creating adversarial test questions.
+
+Given the following documents, generate {num_questions} questions that CANNOT be answered using the information in these documents. These questions should be related to the general topic but ask about information not present.
+
+Documents:
+{documents}
+
+Requirements:
+- Questions should be plausible and related to the topic
+- Questions must NOT be answerable from the documents
+- Questions should sound natural, not obviously unanswerable
+- Avoid questions that are too general or philosophical
+
+Example: If documents are about "Paris landmarks", an out-of-scope question could be "What is the population of Lyon?" (related to France but not in the documents)
+
+Return a JSON array of questions only, nothing else."""
+
+
+# Prompt for generating ambiguous questions
+AMBIGUOUS_PROMPT = """You are an expert at creating adversarial test questions.
+
+Given the following documents, generate {num_questions} ambiguous questions that have multiple valid interpretations or could refer to different things mentioned in the documents.
+
+Documents:
+{documents}
+
+Requirements:
+- Questions should have at least 2 valid interpretations
+- The ambiguity should be natural, not forced
+- Questions should be related to the document content
+- A good RAG system should ask for clarification
+
+Example: If documents mention both "Python the snake" and "Python the language", an ambiguous question could be "How long has Python been around?"
+
+Return a JSON array of questions only, nothing else."""
+
+
+# Prompt for generating misleading questions
+MISLEADING_PROMPT = """You are an expert at creating adversarial test questions.
+
+Given the following documents, generate {num_questions} misleading questions that contain false premises or incorrect assumptions about the content.
+
+Documents:
+{documents}
+
+Requirements:
+- Questions should contain a false statement or assumption
+- The false premise should be subtle but clearly wrong based on the documents
+- A good RAG system should correct the false premise
+- Questions should be related to the actual content
+
+Example: If a document says "Paris was founded in 3rd century BC", a misleading question could be "Why was Paris founded in the 15th century?"
+
+Return a JSON array of questions only, nothing else."""
+
+
+# Prompt for generating boundary/edge case questions
+BOUNDARY_PROMPT = """You are an expert at creating adversarial test questions.
+
+Generate {num_questions} edge case questions that test the boundaries of a RAG system. These should be challenging inputs that might cause issues.
+
+Types of boundary questions to generate:
+- Very short queries (1-2 words)
+- Very long queries (50+ words with multiple clauses)
+- Questions with special characters or formatting
+- Questions mixing multiple topics
+- Questions with typos or unusual phrasing
+
+Context documents (for reference):
+{documents}
+
+Return a JSON array of questions only, nothing else."""
+
+
+class AdversarialQuestion(BaseModel):
+    """An adversarial question with its type and expected behavior.
+
+    Attributes:
+        question: The adversarial question text.
+        adversarial_type: Type of adversarial question.
+        expected_behavior: How the RAG system should respond.
+        explanation: Why this question is adversarial.
+    """
+
+    model_config = {"frozen": True}
+
+    question: str = Field(..., description="The adversarial question")
+    adversarial_type: AdversarialType = Field(..., description="Type of adversarial question")
+    expected_behavior: ExpectedBehavior = Field(..., description="Expected RAG behavior")
+    explanation: str = Field(default="", description="Why this is adversarial")
+
+
+class AdversarialConfig(BaseModel):
+    """Configuration for adversarial question generation.
+
+    Attributes:
+        num_questions: Total number of questions to generate.
+        adversarial_types: Types of adversarial questions to generate.
+        min_chunk_length: Minimum document length to consider.
+    """
+
+    num_questions: int = Field(default=20, ge=1, description="Total questions to generate")
+    adversarial_types: list[AdversarialType] = Field(
+        default_factory=lambda: list(AdversarialType),
+        description="Types of adversarial questions",
+    )
+    min_chunk_length: int = Field(default=50, ge=10, description="Minimum chunk length")
+
+
+class AdversarialQuestionGenerator:
+    """Generates adversarial questions to test RAG system weaknesses.
+
+    This generator creates challenging questions designed to expose
+    potential issues in RAG pipelines.
+
+    Attributes:
+        llm: The LLM provider for generation.
+        config: Generation configuration.
+
+    Example:
+        >>> from ragnarok_ai.adapters import OllamaLLM
+        >>> async with OllamaLLM() as llm:
+        ...     generator = AdversarialQuestionGenerator(llm)
+        ...     testset = await generator.generate(
+        ...         documents=docs,
+        ...         num_questions=20,
+        ...         adversarial_types=["out_of_scope", "ambiguous"],
+        ...     )
+    """
+
+    def __init__(
+        self,
+        llm: LLMProtocol,
+        config: AdversarialConfig | None = None,
+    ) -> None:
+        """Initialize AdversarialQuestionGenerator.
+
+        Args:
+            llm: The LLM provider implementing LLMProtocol.
+            config: Optional generation configuration.
+        """
+        self.llm = llm
+        self.config = config or AdversarialConfig()
+
+    async def generate(
+        self,
+        documents: list[Document],
+        num_questions: int | None = None,
+        adversarial_types: list[str] | None = None,
+    ) -> TestSet:
+        """Generate adversarial questions from documents.
+
+        Args:
+            documents: Source documents for context.
+            num_questions: Override for number of questions.
+            adversarial_types: Override for adversarial types (as strings).
+
+        Returns:
+            TestSet with generated adversarial queries.
+        """
+        target_questions = num_questions or self.config.num_questions
+
+        # Parse adversarial types
+        types = [AdversarialType(t) for t in adversarial_types] if adversarial_types else self.config.adversarial_types
+
+        if not documents:
+            return TestSet(
+                queries=[],
+                name="adversarial_testset",
+                description="Empty test set - no documents provided",
+            )
+
+        # Filter documents by minimum length
+        valid_docs = [doc for doc in documents if len(doc.content) >= self.config.min_chunk_length]
+
+        if not valid_docs:
+            return TestSet(
+                queries=[],
+                name="adversarial_testset",
+                description="Empty test set - no documents met minimum length",
+            )
+
+        # Generate questions for each adversarial type
+        all_questions: list[AdversarialQuestion] = []
+        questions_per_type = max(1, target_questions // len(types))
+
+        for adv_type in types:
+            if len(all_questions) >= target_questions:
+                break
+
+            try:
+                type_questions = await self._generate_for_type(
+                    valid_docs,
+                    adv_type,
+                    num_questions=questions_per_type,
+                )
+                all_questions.extend(type_questions)
+            except Exception:
+                continue
+
+        # Limit to target number
+        all_questions = all_questions[:target_questions]
+
+        # Convert to TestSet format
+        queries = [
+            Query(
+                text=q.question,
+                ground_truth_docs=[],  # Adversarial questions may not have ground truth
+                expected_answer=None,
+                metadata={
+                    "question_type": "adversarial",
+                    "adversarial_type": q.adversarial_type.value,
+                    "expected_behavior": q.expected_behavior.value,
+                    "explanation": q.explanation,
+                },
+            )
+            for q in all_questions
+        ]
+
+        return TestSet(
+            queries=queries,
+            name="adversarial_testset",
+            description=f"Adversarial test set with {len(queries)} questions",
+            metadata={
+                "source_documents": len(documents),
+                "adversarial_types": [t.value for t in types],
+            },
+        )
+
+    async def _generate_for_type(
+        self,
+        documents: list[Document],
+        adversarial_type: AdversarialType,
+        num_questions: int,
+    ) -> list[AdversarialQuestion]:
+        """Generate adversarial questions of a specific type.
+
+        Args:
+            documents: Source documents for context.
+            adversarial_type: Type of adversarial questions to generate.
+            num_questions: Number of questions to generate.
+
+        Returns:
+            List of generated adversarial questions.
+        """
+        # Build documents context
+        docs_text = "\n\n".join([f"Document {i + 1} ({d.id}):\n{d.content}" for i, d in enumerate(documents[:5])])
+
+        # Select prompt based on type
+        prompt_template = self._get_prompt_for_type(adversarial_type)
+        prompt = prompt_template.format(
+            num_questions=num_questions,
+            documents=docs_text,
+        )
+
+        response = await self.llm.generate(prompt)
+        questions = parse_json_array(response)
+
+        # Convert to AdversarialQuestion objects
+        expected_behavior = ADVERSARIAL_EXPECTED_BEHAVIOR[adversarial_type]
+        generated: list[AdversarialQuestion] = []
+
+        for q_text in questions[:num_questions]:
+            if not isinstance(q_text, str) or not q_text.strip():
+                continue
+
+            generated.append(
+                AdversarialQuestion(
+                    question=q_text.strip(),
+                    adversarial_type=adversarial_type,
+                    expected_behavior=expected_behavior,
+                    explanation=self._get_explanation_for_type(adversarial_type),
+                )
+            )
+
+        return generated
+
+    def _get_prompt_for_type(self, adversarial_type: AdversarialType) -> str:
+        """Get the prompt template for an adversarial type.
+
+        Args:
+            adversarial_type: The adversarial type.
+
+        Returns:
+            Prompt template string.
+        """
+        prompts = {
+            AdversarialType.OUT_OF_SCOPE: OUT_OF_SCOPE_PROMPT,
+            AdversarialType.AMBIGUOUS: AMBIGUOUS_PROMPT,
+            AdversarialType.MISLEADING: MISLEADING_PROMPT,
+            AdversarialType.BOUNDARY: BOUNDARY_PROMPT,
+        }
+        return prompts[adversarial_type]
+
+    def _get_explanation_for_type(self, adversarial_type: AdversarialType) -> str:
+        """Get explanation for why a question type is adversarial.
+
+        Args:
+            adversarial_type: The adversarial type.
+
+        Returns:
+            Explanation string.
+        """
+        explanations = {
+            AdversarialType.OUT_OF_SCOPE: "Question asks about information not present in the knowledge base",
+            AdversarialType.AMBIGUOUS: "Question has multiple valid interpretations requiring clarification",
+            AdversarialType.MISLEADING: "Question contains a false premise that should be corrected",
+            AdversarialType.BOUNDARY: "Edge case that tests system robustness",
+        }
+        return explanations[adversarial_type]

--- a/tests/unit/test_adversarial.py
+++ b/tests/unit/test_adversarial.py
@@ -1,0 +1,407 @@
+"""Unit tests for the adversarial question generator."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from ragnarok_ai.core.types import Document, TestSet
+from ragnarok_ai.generators import (
+    AdversarialConfig,
+    AdversarialQuestion,
+    AdversarialQuestionGenerator,
+    AdversarialType,
+    ExpectedBehavior,
+)
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture
+def mock_llm() -> MagicMock:
+    """Create a mock LLM."""
+    llm = MagicMock()
+    llm.generate = AsyncMock()
+    return llm
+
+
+@pytest.fixture
+def sample_documents() -> list[Document]:
+    """Create sample documents for adversarial testing."""
+    return [
+        Document(
+            id="doc_paris",
+            content=(
+                "Paris is the capital of France. It has a population of 2.1 million people. "
+                "The city is known for the Eiffel Tower, built in 1889 by Gustave Eiffel."
+            ),
+        ),
+        Document(
+            id="doc_london",
+            content=(
+                "London is the capital of the United Kingdom. It has a population of 8.8 million. "
+                "Famous landmarks include Big Ben and the Tower of London."
+            ),
+        ),
+    ]
+
+
+# ============================================================================
+# AdversarialType Tests
+# ============================================================================
+
+
+class TestAdversarialType:
+    """Tests for AdversarialType enum."""
+
+    def test_all_types_exist(self) -> None:
+        """Test that all expected types are defined."""
+        assert AdversarialType.OUT_OF_SCOPE == "out_of_scope"
+        assert AdversarialType.AMBIGUOUS == "ambiguous"
+        assert AdversarialType.MISLEADING == "misleading"
+        assert AdversarialType.BOUNDARY == "boundary"
+
+    def test_type_from_string(self) -> None:
+        """Test creating type from string."""
+        assert AdversarialType("out_of_scope") == AdversarialType.OUT_OF_SCOPE
+        assert AdversarialType("ambiguous") == AdversarialType.AMBIGUOUS
+
+
+# ============================================================================
+# ExpectedBehavior Tests
+# ============================================================================
+
+
+class TestExpectedBehavior:
+    """Tests for ExpectedBehavior enum."""
+
+    def test_all_behaviors_exist(self) -> None:
+        """Test that all expected behaviors are defined."""
+        assert ExpectedBehavior.REFUSE == "refuse"
+        assert ExpectedBehavior.CLARIFY == "clarify"
+        assert ExpectedBehavior.CORRECT == "correct"
+        assert ExpectedBehavior.HANDLE_GRACEFULLY == "handle_gracefully"
+
+
+# ============================================================================
+# AdversarialQuestion Tests
+# ============================================================================
+
+
+class TestAdversarialQuestion:
+    """Tests for AdversarialQuestion model."""
+
+    def test_create_question(self) -> None:
+        """Test creating an adversarial question."""
+        question = AdversarialQuestion(
+            question="What is the population of Tokyo?",
+            adversarial_type=AdversarialType.OUT_OF_SCOPE,
+            expected_behavior=ExpectedBehavior.REFUSE,
+            explanation="Tokyo is not mentioned in the documents",
+        )
+        assert question.question == "What is the population of Tokyo?"
+        assert question.adversarial_type == AdversarialType.OUT_OF_SCOPE
+        assert question.expected_behavior == ExpectedBehavior.REFUSE
+
+    def test_question_frozen(self) -> None:
+        """Test that AdversarialQuestion is immutable."""
+        question = AdversarialQuestion(
+            question="Test?",
+            adversarial_type=AdversarialType.AMBIGUOUS,
+            expected_behavior=ExpectedBehavior.CLARIFY,
+        )
+        with pytest.raises(ValidationError):
+            question.question = "Modified?"  # type: ignore[misc]
+
+    def test_question_default_explanation(self) -> None:
+        """Test default explanation is empty string."""
+        question = AdversarialQuestion(
+            question="Test?",
+            adversarial_type=AdversarialType.BOUNDARY,
+            expected_behavior=ExpectedBehavior.HANDLE_GRACEFULLY,
+        )
+        assert question.explanation == ""
+
+
+# ============================================================================
+# AdversarialConfig Tests
+# ============================================================================
+
+
+class TestAdversarialConfig:
+    """Tests for AdversarialConfig model."""
+
+    def test_default_values(self) -> None:
+        """Test default configuration values."""
+        config = AdversarialConfig()
+        assert config.num_questions == 20
+        assert len(config.adversarial_types) == 4  # All types
+        assert config.min_chunk_length == 50
+
+    def test_custom_values(self) -> None:
+        """Test custom configuration values."""
+        config = AdversarialConfig(
+            num_questions=10,
+            adversarial_types=[AdversarialType.OUT_OF_SCOPE, AdversarialType.AMBIGUOUS],
+            min_chunk_length=100,
+        )
+        assert config.num_questions == 10
+        assert len(config.adversarial_types) == 2
+
+    def test_validation_num_questions(self) -> None:
+        """Test that num_questions must be positive."""
+        with pytest.raises(ValidationError):
+            AdversarialConfig(num_questions=0)
+
+
+# ============================================================================
+# AdversarialQuestionGenerator Tests
+# ============================================================================
+
+
+class TestAdversarialQuestionGeneratorInit:
+    """Tests for AdversarialQuestionGenerator initialization."""
+
+    def test_init_with_defaults(self, mock_llm: MagicMock) -> None:
+        """Test initialization with default config."""
+        generator = AdversarialQuestionGenerator(mock_llm)
+        assert generator.llm is mock_llm
+        assert generator.config.num_questions == 20
+
+    def test_init_with_custom_config(self, mock_llm: MagicMock) -> None:
+        """Test initialization with custom config."""
+        config = AdversarialConfig(num_questions=10)
+        generator = AdversarialQuestionGenerator(mock_llm, config=config)
+        assert generator.config.num_questions == 10
+
+
+class TestAdversarialQuestionGeneratorGenerate:
+    """Tests for AdversarialQuestionGenerator.generate method."""
+
+    @pytest.mark.asyncio
+    async def test_generate_empty_documents(self, mock_llm: MagicMock) -> None:
+        """Test generation with empty document list."""
+        generator = AdversarialQuestionGenerator(mock_llm)
+        result = await generator.generate(documents=[])
+        assert isinstance(result, TestSet)
+        assert len(result.queries) == 0
+        assert "no documents provided" in result.description.lower()
+
+    @pytest.mark.asyncio
+    async def test_generate_documents_too_short(self, mock_llm: MagicMock) -> None:
+        """Test generation when documents are too short."""
+        generator = AdversarialQuestionGenerator(mock_llm)
+        short_docs = [Document(id="doc1", content="Short")]
+        result = await generator.generate(documents=short_docs)
+        assert len(result.queries) == 0
+        assert "no documents met minimum length" in result.description.lower()
+
+    @pytest.mark.asyncio
+    async def test_generate_out_of_scope(self, mock_llm: MagicMock, sample_documents: list[Document]) -> None:
+        """Test generating out-of-scope questions."""
+        mock_llm.generate = AsyncMock(return_value='["What is the population of Tokyo?", "Who founded Berlin?"]')
+
+        generator = AdversarialQuestionGenerator(mock_llm)
+        result = await generator.generate(
+            documents=sample_documents,
+            num_questions=2,
+            adversarial_types=["out_of_scope"],
+        )
+
+        assert isinstance(result, TestSet)
+        assert len(result.queries) == 2
+        assert result.queries[0].metadata["adversarial_type"] == "out_of_scope"
+        assert result.queries[0].metadata["expected_behavior"] == "refuse"
+
+    @pytest.mark.asyncio
+    async def test_generate_ambiguous(self, mock_llm: MagicMock, sample_documents: list[Document]) -> None:
+        """Test generating ambiguous questions."""
+        mock_llm.generate = AsyncMock(return_value='["How big is the capital?"]')
+
+        generator = AdversarialQuestionGenerator(mock_llm)
+        result = await generator.generate(
+            documents=sample_documents,
+            num_questions=1,
+            adversarial_types=["ambiguous"],
+        )
+
+        assert len(result.queries) == 1
+        assert result.queries[0].metadata["adversarial_type"] == "ambiguous"
+        assert result.queries[0].metadata["expected_behavior"] == "clarify"
+
+    @pytest.mark.asyncio
+    async def test_generate_misleading(self, mock_llm: MagicMock, sample_documents: list[Document]) -> None:
+        """Test generating misleading questions."""
+        mock_llm.generate = AsyncMock(return_value='["Why was the Eiffel Tower built in 1950?"]')
+
+        generator = AdversarialQuestionGenerator(mock_llm)
+        result = await generator.generate(
+            documents=sample_documents,
+            num_questions=1,
+            adversarial_types=["misleading"],
+        )
+
+        assert len(result.queries) == 1
+        assert result.queries[0].metadata["adversarial_type"] == "misleading"
+        assert result.queries[0].metadata["expected_behavior"] == "correct"
+
+    @pytest.mark.asyncio
+    async def test_generate_boundary(self, mock_llm: MagicMock, sample_documents: list[Document]) -> None:
+        """Test generating boundary/edge case questions."""
+        mock_llm.generate = AsyncMock(return_value='["Paris?", "Tell me everything about..."]')
+
+        generator = AdversarialQuestionGenerator(mock_llm)
+        result = await generator.generate(
+            documents=sample_documents,
+            num_questions=2,
+            adversarial_types=["boundary"],
+        )
+
+        assert len(result.queries) == 2
+        assert result.queries[0].metadata["adversarial_type"] == "boundary"
+        assert result.queries[0].metadata["expected_behavior"] == "handle_gracefully"
+
+    @pytest.mark.asyncio
+    async def test_generate_multiple_types(self, mock_llm: MagicMock, sample_documents: list[Document]) -> None:
+        """Test generating multiple adversarial types."""
+        mock_llm.generate = AsyncMock(
+            side_effect=[
+                '["Out of scope question?"]',
+                '["Ambiguous question?"]',
+            ]
+        )
+
+        generator = AdversarialQuestionGenerator(mock_llm)
+        result = await generator.generate(
+            documents=sample_documents,
+            num_questions=2,
+            adversarial_types=["out_of_scope", "ambiguous"],
+        )
+
+        assert len(result.queries) == 2
+        types = {q.metadata["adversarial_type"] for q in result.queries}
+        assert "out_of_scope" in types
+        assert "ambiguous" in types
+
+    @pytest.mark.asyncio
+    async def test_generate_all_types_by_default(self, mock_llm: MagicMock, sample_documents: list[Document]) -> None:
+        """Test that all types are generated by default."""
+        mock_llm.generate = AsyncMock(return_value='["Question?"]')
+
+        generator = AdversarialQuestionGenerator(mock_llm)
+        result = await generator.generate(
+            documents=sample_documents,
+            num_questions=4,
+        )
+
+        assert result.metadata["adversarial_types"] == ["out_of_scope", "ambiguous", "misleading", "boundary"]
+
+    @pytest.mark.asyncio
+    async def test_generate_handles_llm_error(self, mock_llm: MagicMock, sample_documents: list[Document]) -> None:
+        """Test that generation handles LLM errors gracefully."""
+        mock_llm.generate = AsyncMock(
+            side_effect=[
+                Exception("LLM error"),  # First type fails
+                '["Ambiguous question?"]',  # Second succeeds
+            ]
+        )
+
+        generator = AdversarialQuestionGenerator(mock_llm)
+        result = await generator.generate(
+            documents=sample_documents,
+            num_questions=2,
+            adversarial_types=["out_of_scope", "ambiguous"],
+        )
+
+        # Should still have results from successful type
+        assert isinstance(result, TestSet)
+
+    @pytest.mark.asyncio
+    async def test_generate_no_ground_truth_docs(self, mock_llm: MagicMock, sample_documents: list[Document]) -> None:
+        """Test that adversarial questions have empty ground truth docs."""
+        mock_llm.generate = AsyncMock(return_value='["Out of scope question?"]')
+
+        generator = AdversarialQuestionGenerator(mock_llm)
+        result = await generator.generate(
+            documents=sample_documents,
+            num_questions=1,
+            adversarial_types=["out_of_scope"],
+        )
+
+        assert result.queries[0].ground_truth_docs == []
+        assert result.queries[0].expected_answer is None
+
+    @pytest.mark.asyncio
+    async def test_generate_metadata_includes_explanation(
+        self, mock_llm: MagicMock, sample_documents: list[Document]
+    ) -> None:
+        """Test that metadata includes explanation."""
+        mock_llm.generate = AsyncMock(return_value='["Out of scope question?"]')
+
+        generator = AdversarialQuestionGenerator(mock_llm)
+        result = await generator.generate(
+            documents=sample_documents,
+            num_questions=1,
+            adversarial_types=["out_of_scope"],
+        )
+
+        assert "explanation" in result.queries[0].metadata
+        assert "not present in the knowledge base" in result.queries[0].metadata["explanation"]
+
+
+class TestAdversarialQuestionGeneratorHelpers:
+    """Tests for helper methods."""
+
+    def test_get_prompt_for_type(self, mock_llm: MagicMock) -> None:
+        """Test getting prompts for each type."""
+        generator = AdversarialQuestionGenerator(mock_llm)
+
+        for adv_type in AdversarialType:
+            prompt = generator._get_prompt_for_type(adv_type)
+            assert "{num_questions}" in prompt
+            assert "{documents}" in prompt
+
+    def test_get_explanation_for_type(self, mock_llm: MagicMock) -> None:
+        """Test getting explanations for each type."""
+        generator = AdversarialQuestionGenerator(mock_llm)
+
+        explanations = {
+            AdversarialType.OUT_OF_SCOPE: "not present",
+            AdversarialType.AMBIGUOUS: "multiple valid interpretations",
+            AdversarialType.MISLEADING: "false premise",
+            AdversarialType.BOUNDARY: "robustness",
+        }
+
+        for adv_type, expected_substr in explanations.items():
+            explanation = generator._get_explanation_for_type(adv_type)
+            assert expected_substr in explanation.lower()
+
+    @pytest.mark.asyncio
+    async def test_generate_for_type_invalid_json(self, mock_llm: MagicMock) -> None:
+        """Test handling of invalid JSON response."""
+        mock_llm.generate = AsyncMock(return_value="not valid json")
+
+        generator = AdversarialQuestionGenerator(mock_llm)
+        docs = [Document(id="doc1", content="Some content here for testing." * 5)]
+
+        result = await generator._generate_for_type(docs, AdversarialType.OUT_OF_SCOPE, num_questions=1)
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_generate_for_type_empty_questions(self, mock_llm: MagicMock) -> None:
+        """Test handling of empty question strings."""
+        mock_llm.generate = AsyncMock(return_value='["", "   ", "Valid question?"]')
+
+        generator = AdversarialQuestionGenerator(mock_llm)
+        docs = [Document(id="doc1", content="Some content here for testing." * 5)]
+
+        result = await generator._generate_for_type(docs, AdversarialType.AMBIGUOUS, num_questions=3)
+
+        # Should only include valid question
+        assert len(result) == 1
+        assert result[0].question == "Valid question?"


### PR DESCRIPTION
## Summary

- Add `AdversarialQuestionGenerator` for generating questions that expose RAG weaknesses
- Support 4 adversarial types: out_of_scope, ambiguous, misleading, boundary
- Track expected behavior for each type (refuse, clarify, correct, handle_gracefully)
- `AdversarialType` and `ExpectedBehavior` enums for type safety

## Adversarial Types

| Type | Description | Expected Behavior |
|------|-------------|-------------------|
| `out_of_scope` | Question not in knowledge base | Should refuse or say "I don't know" |
| `ambiguous` | Multiple valid interpretations | Should ask for clarification |
| `misleading` | Contains false premise | Should correct the premise |
| `boundary` | Edge cases | Should handle gracefully |

## Test plan

- [x] 26 unit tests covering all adversarial types
- [x] 92% code coverage
- [x] Lint and type checks pass

Closes #9