### PR TITLE
feat(generators): golden set support (#11)

### DIFF
--- a/src/ragnarok_ai/generators/__init__.py
+++ b/src/ragnarok_ai/generators/__init__.py
@@ -14,6 +14,11 @@ from ragnarok_ai.generators.adversarial import (
     ExpectedBehavior,
 )
 from ragnarok_ai.generators.base import QuestionGeneratorProtocol
+from ragnarok_ai.generators.golden import (
+    GoldenQuestion,
+    GoldenSet,
+    GoldenSetDiff,
+)
 from ragnarok_ai.generators.io import load_testset, save_testset
 from ragnarok_ai.generators.models import GeneratedQuestion, GenerationConfig
 from ragnarok_ai.generators.multihop import (
@@ -37,6 +42,9 @@ __all__ = [
     "ExpectedBehavior",
     "GeneratedQuestion",
     "GenerationConfig",
+    "GoldenQuestion",
+    "GoldenSet",
+    "GoldenSetDiff",
     "MultiHopConfig",
     "MultiHopQuestion",
     "MultiHopQuestionGenerator",

--- a/src/ragnarok_ai/generators/golden.py
+++ b/src/ragnarok_ai/generators/golden.py
@@ -1,0 +1,424 @@
+"""Golden set support for ragnarok-ai.
+
+This module provides support for human-validated, versioned question sets
+(golden sets) for production RAG evaluation.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+from io import StringIO
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, Field
+
+from ragnarok_ai.core.types import Query, TestSet
+
+
+class GoldenQuestion(BaseModel):
+    """A human-validated question with verified answer.
+
+    Attributes:
+        id: Unique identifier for the question.
+        question: The question text.
+        answer: The verified correct answer.
+        tags: List of tags for categorization.
+        source_docs: List of source document IDs.
+        validated_by: Who validated this question.
+        validated_at: When the question was validated.
+        difficulty: Difficulty level (easy, medium, hard).
+        priority: Priority level (low, medium, high, critical).
+        metadata: Additional metadata.
+    """
+
+    id: str = Field(..., description="Unique question identifier")
+    question: str = Field(..., description="The question text")
+    answer: str = Field(..., description="The verified correct answer")
+    tags: list[str] = Field(default_factory=list, description="Categorization tags")
+    source_docs: list[str] = Field(default_factory=list, description="Source document IDs")
+    validated_by: str | None = Field(default=None, description="Validator identity")
+    validated_at: str | None = Field(default=None, description="Validation timestamp")
+    difficulty: str | None = Field(default=None, description="Difficulty level")
+    priority: str | None = Field(default=None, description="Priority level")
+    metadata: dict[str, Any] = Field(default_factory=dict, description="Additional metadata")
+
+
+class GoldenSetDiff(BaseModel):
+    """Represents differences between two golden set versions.
+
+    Attributes:
+        old_version: Version of the old set.
+        new_version: Version of the new set.
+        added: Questions added in new version.
+        removed: Questions removed from old version.
+        modified: Questions that changed.
+        unchanged: Questions that stayed the same.
+    """
+
+    old_version: str = Field(..., description="Old version")
+    new_version: str = Field(..., description="New version")
+    added: list[str] = Field(default_factory=list, description="Added question IDs")
+    removed: list[str] = Field(default_factory=list, description="Removed question IDs")
+    modified: list[str] = Field(default_factory=list, description="Modified question IDs")
+    unchanged: list[str] = Field(default_factory=list, description="Unchanged question IDs")
+
+    @property
+    def has_changes(self) -> bool:
+        """Check if there are any changes."""
+        return bool(self.added or self.removed or self.modified)
+
+    @property
+    def summary(self) -> str:
+        """Get a summary of changes."""
+        parts = []
+        if self.added:
+            parts.append(f"+{len(self.added)} added")
+        if self.removed:
+            parts.append(f"-{len(self.removed)} removed")
+        if self.modified:
+            parts.append(f"~{len(self.modified)} modified")
+        if self.unchanged:
+            parts.append(f"={len(self.unchanged)} unchanged")
+        return ", ".join(parts) if parts else "no changes"
+
+
+class GoldenSet(BaseModel):
+    """A versioned collection of human-validated questions.
+
+    Attributes:
+        version: Version string for this golden set.
+        name: Name of the golden set.
+        description: Description of the golden set.
+        questions: List of golden questions.
+        metadata: Additional metadata.
+
+    Example:
+        >>> golden = GoldenSet.load("golden_set.yaml")
+        >>> critical = golden.filter(tags=["critical"])
+        >>> results = await evaluate(rag, critical.to_testset())
+    """
+
+    version: str = Field(default="1.0.0", description="Version string")
+    name: str | None = Field(default=None, description="Golden set name")
+    description: str | None = Field(default=None, description="Description")
+    questions: list[GoldenQuestion] = Field(default_factory=list, description="Golden questions")
+    metadata: dict[str, Any] = Field(default_factory=dict, description="Additional metadata")
+
+    def __len__(self) -> int:
+        """Return number of questions."""
+        return len(self.questions)
+
+    def __iter__(self) -> Any:
+        """Iterate over questions."""
+        return iter(self.questions)
+
+    def get_by_id(self, question_id: str) -> GoldenQuestion | None:
+        """Get a question by its ID.
+
+        Args:
+            question_id: The question ID to find.
+
+        Returns:
+            The question if found, None otherwise.
+        """
+        for q in self.questions:
+            if q.id == question_id:
+                return q
+        return None
+
+    def filter(
+        self,
+        tags: list[str] | None = None,
+        difficulty: str | None = None,
+        priority: str | None = None,
+        ids: list[str] | None = None,
+    ) -> GoldenSet:
+        """Filter questions by criteria.
+
+        Args:
+            tags: Only include questions with any of these tags.
+            difficulty: Only include questions with this difficulty.
+            priority: Only include questions with this priority.
+            ids: Only include questions with these IDs.
+
+        Returns:
+            New GoldenSet with filtered questions.
+        """
+        filtered = self.questions
+
+        if tags:
+            filtered = [q for q in filtered if any(t in q.tags for t in tags)]
+
+        if difficulty:
+            filtered = [q for q in filtered if q.difficulty == difficulty]
+
+        if priority:
+            filtered = [q for q in filtered if q.priority == priority]
+
+        if ids:
+            filtered = [q for q in filtered if q.id in ids]
+
+        return GoldenSet(
+            version=self.version,
+            name=self.name,
+            description=self.description,
+            questions=filtered,
+            metadata=self.metadata,
+        )
+
+    def get_tags(self) -> set[str]:
+        """Get all unique tags in the golden set.
+
+        Returns:
+            Set of all tags.
+        """
+        tags: set[str] = set()
+        for q in self.questions:
+            tags.update(q.tags)
+        return tags
+
+    def get_difficulties(self) -> set[str]:
+        """Get all unique difficulty levels.
+
+        Returns:
+            Set of difficulty levels.
+        """
+        return {q.difficulty for q in self.questions if q.difficulty}
+
+    def get_priorities(self) -> set[str]:
+        """Get all unique priority levels.
+
+        Returns:
+            Set of priority levels.
+        """
+        return {q.priority for q in self.questions if q.priority}
+
+    def to_testset(self) -> TestSet:
+        """Convert to a TestSet for evaluation.
+
+        Returns:
+            TestSet with queries from golden questions.
+        """
+        queries = [
+            Query(
+                text=q.question,
+                ground_truth_docs=q.source_docs,
+                expected_answer=q.answer,
+                metadata={
+                    "golden_id": q.id,
+                    "tags": q.tags,
+                    "difficulty": q.difficulty,
+                    "priority": q.priority,
+                    "validated_by": q.validated_by,
+                    "validated_at": q.validated_at,
+                },
+            )
+            for q in self.questions
+        ]
+
+        return TestSet(
+            queries=queries,
+            name=self.name or f"golden_set_v{self.version}",
+            description=self.description or f"Golden set version {self.version}",
+            metadata={
+                "golden_version": self.version,
+                **self.metadata,
+            },
+        )
+
+    def diff(self, other: GoldenSet) -> GoldenSetDiff:
+        """Compare this golden set with another.
+
+        Args:
+            other: The other golden set to compare with.
+
+        Returns:
+            GoldenSetDiff with the differences.
+        """
+        self_ids = {q.id for q in self.questions}
+        other_ids = {q.id for q in other.questions}
+
+        added = list(other_ids - self_ids)
+        removed = list(self_ids - other_ids)
+
+        # Check for modifications in common questions
+        common_ids = self_ids & other_ids
+        modified = []
+        unchanged = []
+
+        for qid in common_ids:
+            self_q = self.get_by_id(qid)
+            other_q = other.get_by_id(qid)
+
+            if self_q and other_q:
+                # Compare question and answer (main content)
+                if self_q.question != other_q.question or self_q.answer != other_q.answer:
+                    modified.append(qid)
+                else:
+                    unchanged.append(qid)
+
+        return GoldenSetDiff(
+            old_version=self.version,
+            new_version=other.version,
+            added=sorted(added),
+            removed=sorted(removed),
+            modified=sorted(modified),
+            unchanged=sorted(unchanged),
+        )
+
+    def save(self, path: Path | str, format: str | None = None) -> None:
+        """Save golden set to file.
+
+        Args:
+            path: Output file path.
+            format: Format to use (json, yaml, csv). Auto-detected from extension if not provided.
+        """
+        path = Path(path)
+        fmt = format or self._detect_format(path)
+
+        if fmt == "yaml":
+            self._save_yaml(path)
+        elif fmt == "csv":
+            self._save_csv(path)
+        else:
+            self._save_json(path)
+
+    @classmethod
+    def load(cls, path: Path | str, format: str | None = None) -> GoldenSet:
+        """Load golden set from file.
+
+        Args:
+            path: Input file path.
+            format: Format to use (json, yaml, csv). Auto-detected from extension if not provided.
+
+        Returns:
+            Loaded GoldenSet.
+        """
+        path = Path(path)
+        fmt = format or cls._detect_format(path)
+
+        if fmt == "yaml":
+            return cls._load_yaml(path)
+        elif fmt == "csv":
+            return cls._load_csv(path)
+        else:
+            return cls._load_json(path)
+
+    @staticmethod
+    def _detect_format(path: Path) -> str:
+        """Detect format from file extension."""
+        suffix = path.suffix.lower()
+        if suffix in (".yaml", ".yml"):
+            return "yaml"
+        elif suffix == ".csv":
+            return "csv"
+        return "json"
+
+    def _save_json(self, path: Path) -> None:
+        """Save as JSON."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        data = {
+            "version": self.version,
+            "name": self.name,
+            "description": self.description,
+            "metadata": self.metadata,
+            "questions": [q.model_dump() for q in self.questions],
+        }
+        path.write_text(json.dumps(data, indent=2))
+
+    def _save_yaml(self, path: Path) -> None:
+        """Save as YAML."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        data = {
+            "version": self.version,
+            "name": self.name,
+            "description": self.description,
+            "metadata": self.metadata,
+            "questions": [q.model_dump() for q in self.questions],
+        }
+        path.write_text(yaml.safe_dump(data, default_flow_style=False, allow_unicode=True))
+
+    def _save_csv(self, path: Path) -> None:
+        """Save as CSV."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        output = StringIO()
+        fieldnames = [
+            "id",
+            "question",
+            "answer",
+            "tags",
+            "source_docs",
+            "validated_by",
+            "validated_at",
+            "difficulty",
+            "priority",
+        ]
+        writer = csv.DictWriter(output, fieldnames=fieldnames)
+        writer.writeheader()
+
+        for q in self.questions:
+            writer.writerow(
+                {
+                    "id": q.id,
+                    "question": q.question,
+                    "answer": q.answer,
+                    "tags": ";".join(q.tags),
+                    "source_docs": ";".join(q.source_docs),
+                    "validated_by": q.validated_by or "",
+                    "validated_at": q.validated_at or "",
+                    "difficulty": q.difficulty or "",
+                    "priority": q.priority or "",
+                }
+            )
+
+        path.write_text(output.getvalue())
+
+    @classmethod
+    def _load_json(cls, path: Path) -> GoldenSet:
+        """Load from JSON."""
+        data = json.loads(path.read_text())
+        return cls._from_dict(data)
+
+    @classmethod
+    def _load_yaml(cls, path: Path) -> GoldenSet:
+        """Load from YAML."""
+        data = yaml.safe_load(path.read_text())
+        return cls._from_dict(data)
+
+    @classmethod
+    def _load_csv(cls, path: Path) -> GoldenSet:
+        """Load from CSV."""
+        questions = []
+        reader = csv.DictReader(StringIO(path.read_text()))
+
+        for row in reader:
+            questions.append(
+                GoldenQuestion(
+                    id=row["id"],
+                    question=row["question"],
+                    answer=row["answer"],
+                    tags=row.get("tags", "").split(";") if row.get("tags") else [],
+                    source_docs=row.get("source_docs", "").split(";") if row.get("source_docs") else [],
+                    validated_by=row.get("validated_by") or None,
+                    validated_at=row.get("validated_at") or None,
+                    difficulty=row.get("difficulty") or None,
+                    priority=row.get("priority") or None,
+                )
+            )
+
+        return cls(version="1.0.0", questions=questions)
+
+    @classmethod
+    def _from_dict(cls, data: dict[str, Any]) -> GoldenSet:
+        """Create from dictionary."""
+        questions = [GoldenQuestion(**q) for q in data.get("questions", [])]
+        return cls(
+            version=data.get("version", "1.0.0"),
+            name=data.get("name"),
+            description=data.get("description"),
+            questions=questions,
+            metadata=data.get("metadata", {}),
+        )

--- a/tests/unit/test_golden.py
+++ b/tests/unit/test_golden.py
@@ -1,0 +1,481 @@
+"""Unit tests for the golden set module."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from ragnarok_ai.core.types import TestSet
+from ragnarok_ai.generators import (
+    GoldenQuestion,
+    GoldenSet,
+    GoldenSetDiff,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# ============================================================================
+# GoldenQuestion Tests
+# ============================================================================
+
+
+class TestGoldenQuestion:
+    """Tests for GoldenQuestion model."""
+
+    def test_create_with_required_fields(self) -> None:
+        """Test creating a question with required fields."""
+        question = GoldenQuestion(
+            id="q001",
+            question="What is the refund policy?",
+            answer="Full refund within 30 days.",
+        )
+        assert question.id == "q001"
+        assert question.question == "What is the refund policy?"
+        assert question.answer == "Full refund within 30 days."
+
+    def test_create_with_all_fields(self) -> None:
+        """Test creating a question with all fields."""
+        question = GoldenQuestion(
+            id="q001",
+            question="What is the refund policy?",
+            answer="Full refund within 30 days.",
+            tags=["policy", "critical"],
+            source_docs=["policies/refund.md"],
+            validated_by="john@example.com",
+            validated_at="2024-01-15",
+            difficulty="easy",
+            priority="critical",
+            metadata={"category": "support"},
+        )
+        assert question.tags == ["policy", "critical"]
+        assert question.validated_by == "john@example.com"
+        assert question.priority == "critical"
+
+    def test_default_values(self) -> None:
+        """Test default values."""
+        question = GoldenQuestion(id="q001", question="Test?", answer="Yes")
+        assert question.tags == []
+        assert question.source_docs == []
+        assert question.validated_by is None
+        assert question.difficulty is None
+        assert question.metadata == {}
+
+
+# ============================================================================
+# GoldenSetDiff Tests
+# ============================================================================
+
+
+class TestGoldenSetDiff:
+    """Tests for GoldenSetDiff model."""
+
+    def test_has_changes_true(self) -> None:
+        """Test has_changes when there are changes."""
+        diff = GoldenSetDiff(
+            old_version="1.0.0",
+            new_version="1.1.0",
+            added=["q003"],
+            removed=[],
+            modified=[],
+            unchanged=["q001", "q002"],
+        )
+        assert diff.has_changes is True
+
+    def test_has_changes_false(self) -> None:
+        """Test has_changes when no changes."""
+        diff = GoldenSetDiff(
+            old_version="1.0.0",
+            new_version="1.0.0",
+            added=[],
+            removed=[],
+            modified=[],
+            unchanged=["q001", "q002"],
+        )
+        assert diff.has_changes is False
+
+    def test_summary(self) -> None:
+        """Test summary generation."""
+        diff = GoldenSetDiff(
+            old_version="1.0.0",
+            new_version="1.1.0",
+            added=["q003"],
+            removed=["q004"],
+            modified=["q002"],
+            unchanged=["q001"],
+        )
+        assert "+1 added" in diff.summary
+        assert "-1 removed" in diff.summary
+        assert "~1 modified" in diff.summary
+        assert "=1 unchanged" in diff.summary
+
+    def test_summary_no_changes(self) -> None:
+        """Test summary with no changes."""
+        diff = GoldenSetDiff(
+            old_version="1.0.0",
+            new_version="1.0.0",
+            added=[],
+            removed=[],
+            modified=[],
+            unchanged=[],
+        )
+        assert diff.summary == "no changes"
+
+
+# ============================================================================
+# GoldenSet Tests
+# ============================================================================
+
+
+class TestGoldenSetBasic:
+    """Basic tests for GoldenSet."""
+
+    def test_create_empty(self) -> None:
+        """Test creating an empty golden set."""
+        golden = GoldenSet(version="1.0.0")
+        assert golden.version == "1.0.0"
+        assert len(golden) == 0
+
+    def test_create_with_questions(self) -> None:
+        """Test creating golden set with questions."""
+        questions = [
+            GoldenQuestion(id="q001", question="Q1?", answer="A1"),
+            GoldenQuestion(id="q002", question="Q2?", answer="A2"),
+        ]
+        golden = GoldenSet(version="1.0.0", questions=questions)
+        assert len(golden) == 2
+
+    def test_iteration(self) -> None:
+        """Test iterating over questions."""
+        questions = [
+            GoldenQuestion(id="q001", question="Q1?", answer="A1"),
+            GoldenQuestion(id="q002", question="Q2?", answer="A2"),
+        ]
+        golden = GoldenSet(questions=questions)
+
+        ids = [q.id for q in golden]
+        assert ids == ["q001", "q002"]
+
+    def test_get_by_id(self) -> None:
+        """Test getting question by ID."""
+        questions = [
+            GoldenQuestion(id="q001", question="Q1?", answer="A1"),
+            GoldenQuestion(id="q002", question="Q2?", answer="A2"),
+        ]
+        golden = GoldenSet(questions=questions)
+
+        q = golden.get_by_id("q002")
+        assert q is not None
+        assert q.question == "Q2?"
+
+    def test_get_by_id_not_found(self) -> None:
+        """Test getting non-existent question."""
+        golden = GoldenSet(questions=[])
+        assert golden.get_by_id("nonexistent") is None
+
+
+class TestGoldenSetFilter:
+    """Tests for GoldenSet filtering."""
+
+    @pytest.fixture
+    def sample_golden_set(self) -> GoldenSet:
+        """Create a sample golden set for testing."""
+        return GoldenSet(
+            version="1.0.0",
+            questions=[
+                GoldenQuestion(
+                    id="q001",
+                    question="Q1?",
+                    answer="A1",
+                    tags=["policy", "critical"],
+                    difficulty="easy",
+                    priority="high",
+                ),
+                GoldenQuestion(
+                    id="q002",
+                    question="Q2?",
+                    answer="A2",
+                    tags=["technical"],
+                    difficulty="hard",
+                    priority="low",
+                ),
+                GoldenQuestion(
+                    id="q003",
+                    question="Q3?",
+                    answer="A3",
+                    tags=["policy"],
+                    difficulty="easy",
+                    priority="critical",
+                ),
+            ],
+        )
+
+    def test_filter_by_tags(self, sample_golden_set: GoldenSet) -> None:
+        """Test filtering by tags."""
+        filtered = sample_golden_set.filter(tags=["policy"])
+        assert len(filtered) == 2
+        assert all("policy" in q.tags for q in filtered)
+
+    def test_filter_by_multiple_tags(self, sample_golden_set: GoldenSet) -> None:
+        """Test filtering by multiple tags (OR)."""
+        filtered = sample_golden_set.filter(tags=["critical", "technical"])
+        assert len(filtered) == 2
+
+    def test_filter_by_difficulty(self, sample_golden_set: GoldenSet) -> None:
+        """Test filtering by difficulty."""
+        filtered = sample_golden_set.filter(difficulty="easy")
+        assert len(filtered) == 2
+        assert all(q.difficulty == "easy" for q in filtered)
+
+    def test_filter_by_priority(self, sample_golden_set: GoldenSet) -> None:
+        """Test filtering by priority."""
+        filtered = sample_golden_set.filter(priority="critical")
+        assert len(filtered) == 1
+        assert filtered.questions[0].id == "q003"
+
+    def test_filter_by_ids(self, sample_golden_set: GoldenSet) -> None:
+        """Test filtering by IDs."""
+        filtered = sample_golden_set.filter(ids=["q001", "q003"])
+        assert len(filtered) == 2
+
+    def test_filter_combined(self, sample_golden_set: GoldenSet) -> None:
+        """Test combined filtering."""
+        filtered = sample_golden_set.filter(tags=["policy"], difficulty="easy")
+        assert len(filtered) == 2
+
+    def test_filter_preserves_metadata(self, sample_golden_set: GoldenSet) -> None:
+        """Test that filtering preserves set metadata."""
+        filtered = sample_golden_set.filter(tags=["policy"])
+        assert filtered.version == sample_golden_set.version
+
+
+class TestGoldenSetMetadata:
+    """Tests for GoldenSet metadata methods."""
+
+    @pytest.fixture
+    def sample_golden_set(self) -> GoldenSet:
+        """Create a sample golden set."""
+        return GoldenSet(
+            questions=[
+                GoldenQuestion(
+                    id="q001", question="Q1?", answer="A1", tags=["a", "b"], difficulty="easy", priority="high"
+                ),
+                GoldenQuestion(
+                    id="q002", question="Q2?", answer="A2", tags=["b", "c"], difficulty="hard", priority="low"
+                ),
+            ]
+        )
+
+    def test_get_tags(self, sample_golden_set: GoldenSet) -> None:
+        """Test getting all tags."""
+        tags = sample_golden_set.get_tags()
+        assert tags == {"a", "b", "c"}
+
+    def test_get_difficulties(self, sample_golden_set: GoldenSet) -> None:
+        """Test getting all difficulties."""
+        difficulties = sample_golden_set.get_difficulties()
+        assert difficulties == {"easy", "hard"}
+
+    def test_get_priorities(self, sample_golden_set: GoldenSet) -> None:
+        """Test getting all priorities."""
+        priorities = sample_golden_set.get_priorities()
+        assert priorities == {"high", "low"}
+
+
+class TestGoldenSetToTestSet:
+    """Tests for converting GoldenSet to TestSet."""
+
+    def test_to_testset(self) -> None:
+        """Test conversion to TestSet."""
+        golden = GoldenSet(
+            version="1.0.0",
+            name="Test Golden",
+            description="Test description",
+            questions=[
+                GoldenQuestion(
+                    id="q001",
+                    question="What is X?",
+                    answer="X is Y",
+                    tags=["test"],
+                    source_docs=["doc1.md"],
+                    validated_by="tester",
+                    difficulty="easy",
+                    priority="high",
+                ),
+            ],
+        )
+
+        testset = golden.to_testset()
+
+        assert isinstance(testset, TestSet)
+        assert len(testset.queries) == 1
+        assert testset.queries[0].text == "What is X?"
+        assert testset.queries[0].expected_answer == "X is Y"
+        assert testset.queries[0].ground_truth_docs == ["doc1.md"]
+        assert testset.queries[0].metadata["golden_id"] == "q001"
+        assert testset.metadata["golden_version"] == "1.0.0"
+
+
+class TestGoldenSetDiffMethod:
+    """Tests for GoldenSet.diff method."""
+
+    def test_diff_no_changes(self) -> None:
+        """Test diff with identical sets."""
+        golden1 = GoldenSet(
+            version="1.0.0",
+            questions=[GoldenQuestion(id="q001", question="Q?", answer="A")],
+        )
+        golden2 = GoldenSet(
+            version="1.0.0",
+            questions=[GoldenQuestion(id="q001", question="Q?", answer="A")],
+        )
+
+        diff = golden1.diff(golden2)
+        assert diff.added == []
+        assert diff.removed == []
+        assert diff.modified == []
+        assert diff.unchanged == ["q001"]
+
+    def test_diff_added(self) -> None:
+        """Test diff with added questions."""
+        golden1 = GoldenSet(
+            version="1.0.0",
+            questions=[GoldenQuestion(id="q001", question="Q1?", answer="A1")],
+        )
+        golden2 = GoldenSet(
+            version="1.1.0",
+            questions=[
+                GoldenQuestion(id="q001", question="Q1?", answer="A1"),
+                GoldenQuestion(id="q002", question="Q2?", answer="A2"),
+            ],
+        )
+
+        diff = golden1.diff(golden2)
+        assert diff.added == ["q002"]
+        assert diff.removed == []
+        assert diff.unchanged == ["q001"]
+
+    def test_diff_removed(self) -> None:
+        """Test diff with removed questions."""
+        golden1 = GoldenSet(
+            version="1.0.0",
+            questions=[
+                GoldenQuestion(id="q001", question="Q1?", answer="A1"),
+                GoldenQuestion(id="q002", question="Q2?", answer="A2"),
+            ],
+        )
+        golden2 = GoldenSet(
+            version="1.1.0",
+            questions=[GoldenQuestion(id="q001", question="Q1?", answer="A1")],
+        )
+
+        diff = golden1.diff(golden2)
+        assert diff.added == []
+        assert diff.removed == ["q002"]
+
+    def test_diff_modified(self) -> None:
+        """Test diff with modified questions."""
+        golden1 = GoldenSet(
+            version="1.0.0",
+            questions=[GoldenQuestion(id="q001", question="Q?", answer="Old answer")],
+        )
+        golden2 = GoldenSet(
+            version="1.1.0",
+            questions=[GoldenQuestion(id="q001", question="Q?", answer="New answer")],
+        )
+
+        diff = golden1.diff(golden2)
+        assert diff.modified == ["q001"]
+        assert diff.unchanged == []
+
+
+class TestGoldenSetIO:
+    """Tests for GoldenSet save/load functionality."""
+
+    @pytest.fixture
+    def sample_golden_set(self) -> GoldenSet:
+        """Create a sample golden set."""
+        return GoldenSet(
+            version="1.0.0",
+            name="Test Set",
+            description="Test description",
+            questions=[
+                GoldenQuestion(
+                    id="q001",
+                    question="What is X?",
+                    answer="X is Y",
+                    tags=["test", "example"],
+                    source_docs=["doc1.md"],
+                    validated_by="tester",
+                    validated_at="2024-01-15",
+                    difficulty="easy",
+                    priority="high",
+                ),
+            ],
+            metadata={"source": "test"},
+        )
+
+    def test_save_load_json(self, tmp_path: Path, sample_golden_set: GoldenSet) -> None:
+        """Test saving and loading JSON."""
+        path = tmp_path / "golden.json"
+        sample_golden_set.save(path)
+
+        loaded = GoldenSet.load(path)
+        assert loaded.version == sample_golden_set.version
+        assert loaded.name == sample_golden_set.name
+        assert len(loaded) == len(sample_golden_set)
+        assert loaded.questions[0].id == "q001"
+
+    def test_save_load_yaml(self, tmp_path: Path, sample_golden_set: GoldenSet) -> None:
+        """Test saving and loading YAML."""
+        path = tmp_path / "golden.yaml"
+        sample_golden_set.save(path)
+
+        loaded = GoldenSet.load(path)
+        assert loaded.version == sample_golden_set.version
+        assert len(loaded) == len(sample_golden_set)
+
+    def test_save_load_yml(self, tmp_path: Path, sample_golden_set: GoldenSet) -> None:
+        """Test saving and loading .yml extension."""
+        path = tmp_path / "golden.yml"
+        sample_golden_set.save(path)
+
+        loaded = GoldenSet.load(path)
+        assert loaded.version == sample_golden_set.version
+
+    def test_save_load_csv(self, tmp_path: Path, sample_golden_set: GoldenSet) -> None:
+        """Test saving and loading CSV."""
+        path = tmp_path / "golden.csv"
+        sample_golden_set.save(path)
+
+        loaded = GoldenSet.load(path)
+        assert len(loaded) == len(sample_golden_set)
+        assert loaded.questions[0].id == "q001"
+        assert loaded.questions[0].tags == ["test", "example"]
+
+    def test_save_explicit_format(self, tmp_path: Path, sample_golden_set: GoldenSet) -> None:
+        """Test saving with explicit format."""
+        path = tmp_path / "golden.txt"
+        sample_golden_set.save(path, format="json")
+
+        loaded = GoldenSet.load(path, format="json")
+        assert loaded.version == sample_golden_set.version
+
+    def test_save_creates_parent_dirs(self, tmp_path: Path, sample_golden_set: GoldenSet) -> None:
+        """Test that save creates parent directories."""
+        path = tmp_path / "subdir" / "nested" / "golden.json"
+        sample_golden_set.save(path)
+        assert path.exists()
+
+    def test_csv_handles_empty_fields(self, tmp_path: Path) -> None:
+        """Test CSV handles empty optional fields."""
+        golden = GoldenSet(
+            questions=[GoldenQuestion(id="q001", question="Q?", answer="A")],
+        )
+        path = tmp_path / "golden.csv"
+        golden.save(path)
+
+        loaded = GoldenSet.load(path)
+        assert loaded.questions[0].validated_by is None
+        assert loaded.questions[0].tags == []


### PR DESCRIPTION
## Summary

- Add `GoldenSet` for human-validated, versioned question sets
- Support for JSON, YAML, and CSV import/export
- Filtering by tags, difficulty, priority
- Version diffing to track changes between versions
- Convert to `TestSet` for evaluation integration

## Schema

```yaml
version: "1.0.0"
questions:
  - id: "q001"
    question: "What is the refund policy?"
    answer: "Full refund within 30 days."
    tags: ["policy", "critical"]
    source_docs: ["policies/refund.md"]
    validated_by: "john@example.com"
    validated_at: "2024-01-15"
    difficulty: "easy"
    priority: "critical"
```

## Usage

```python
golden = GoldenSet.load("golden_set.yaml")
critical = golden.filter(tags=["critical"])
results = await evaluate(rag, critical.to_testset())

# Compare versions
diff = golden.diff(old_golden)
print(diff.summary)  # "+2 added, -1 removed, ~1 modified"
```

## Test plan

- [x] 34 unit tests covering all functionality
- [x] 93% code coverage
- [x] Lint and type checks pass

Closes #11