### PR TITLE
feat(adapters): add LangGraph integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,10 @@ module = ["langchain_core", "langchain_core.*"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
+module = ["langgraph", "langgraph.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
 module = ["yaml", "yaml.*"]
 ignore_missing_imports = true
 

--- a/src/ragnarok_ai/adapters/__init__.py
+++ b/src/ragnarok_ai/adapters/__init__.py
@@ -8,13 +8,20 @@ This module provides adapters for external services:
 
 from __future__ import annotations
 
-from ragnarok_ai.adapters.frameworks import LangChainAdapter, LangChainRetrieverAdapter
+from ragnarok_ai.adapters.frameworks import (
+    LangChainAdapter,
+    LangChainRetrieverAdapter,
+    LangGraphAdapter,
+    LangGraphStreamAdapter,
+)
 from ragnarok_ai.adapters.llm import OllamaLLM
 from ragnarok_ai.adapters.vectorstore import QdrantVectorStore
 
 __all__ = [
     "LangChainAdapter",
     "LangChainRetrieverAdapter",
+    "LangGraphAdapter",
+    "LangGraphStreamAdapter",
     "OllamaLLM",
     "QdrantVectorStore",
 ]

--- a/src/ragnarok_ai/adapters/frameworks/__init__.py
+++ b/src/ragnarok_ai/adapters/frameworks/__init__.py
@@ -9,8 +9,14 @@ from ragnarok_ai.adapters.frameworks.langchain import (
     LangChainAdapter,
     LangChainRetrieverAdapter,
 )
+from ragnarok_ai.adapters.frameworks.langgraph import (
+    LangGraphAdapter,
+    LangGraphStreamAdapter,
+)
 
 __all__ = [
     "LangChainAdapter",
     "LangChainRetrieverAdapter",
+    "LangGraphAdapter",
+    "LangGraphStreamAdapter",
 ]

--- a/src/ragnarok_ai/adapters/frameworks/langgraph.py
+++ b/src/ragnarok_ai/adapters/frameworks/langgraph.py
@@ -1,0 +1,321 @@
+"""LangGraph adapter for ragnarok-ai.
+
+This module provides adapters to evaluate LangGraph stateful RAG agents.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+
+from ragnarok_ai.core.types import Document, RAGResponse
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+    from langgraph.graph import StateGraph
+    from langgraph.graph.state import CompiledStateGraph
+
+
+def _extract_documents_from_state(
+    state: dict[str, Any],
+    docs_keys: Sequence[str],
+) -> list[Document]:
+    """Extract documents from graph state.
+
+    Args:
+        state: The graph state dictionary.
+        docs_keys: Keys to search for documents in state.
+
+    Returns:
+        List of extracted documents.
+    """
+    documents: list[Document] = []
+
+    for key in docs_keys:
+        if key not in state:
+            continue
+
+        raw_docs = state[key]
+        if not raw_docs:
+            continue
+
+        # Handle list of documents
+        if isinstance(raw_docs, list):
+            for i, doc in enumerate(raw_docs):
+                if isinstance(doc, Document):
+                    documents.append(doc)
+                elif hasattr(doc, "page_content"):
+                    # LangChain Document
+                    doc_id = doc.metadata.get("id") or doc.metadata.get("source") or str(hash(doc.page_content))
+                    documents.append(
+                        Document(
+                            id=str(doc_id),
+                            content=doc.page_content,
+                            metadata=doc.metadata,
+                        )
+                    )
+                elif isinstance(doc, dict):
+                    documents.append(
+                        Document(
+                            id=str(doc.get("id", i)),
+                            content=str(doc.get("content", doc.get("page_content", ""))),
+                            metadata=doc.get("metadata", {}),
+                        )
+                    )
+                elif isinstance(doc, str):
+                    documents.append(
+                        Document(
+                            id=f"{key}_{i}",
+                            content=doc,
+                            metadata={"source_key": key},
+                        )
+                    )
+
+    return documents
+
+
+def _extract_answer_from_state(
+    state: dict[str, Any],
+    answer_keys: Sequence[str],
+) -> str:
+    """Extract answer from graph state.
+
+    Args:
+        state: The graph state dictionary.
+        answer_keys: Keys to search for answer in state.
+
+    Returns:
+        Extracted answer string.
+    """
+    for key in answer_keys:
+        value = state.get(key)
+        if value:
+            if isinstance(value, str):
+                return value
+            if isinstance(value, list) and value:
+                # Take last message if it's a list
+                last = value[-1]
+                if isinstance(last, str):
+                    return last
+                if hasattr(last, "content"):
+                    return str(last.content)
+                return str(last)
+            return str(value)
+    return ""
+
+
+class LangGraphAdapter:
+    """Adapter for LangGraph StateGraph and CompiledStateGraph.
+
+    Wraps a LangGraph graph for use with ragnarok-ai evaluation.
+    Automatically extracts retrieved documents and answers from graph state.
+
+    Attributes:
+        graph: The wrapped LangGraph graph.
+
+    Example:
+        >>> from langgraph.graph import StateGraph
+        >>> from ragnarok_ai.adapters.frameworks import LangGraphAdapter
+        >>>
+        >>> # Define your graph
+        >>> graph = StateGraph(AgentState)
+        >>> graph.add_node("retrieve", retrieve_node)
+        >>> graph.add_node("generate", generate_node)
+        >>> # ... add edges
+        >>> compiled = graph.compile()
+        >>>
+        >>> # Wrap for evaluation
+        >>> adapter = LangGraphAdapter(compiled)
+        >>> results = await evaluate(adapter, testset)
+
+    Example with custom extraction:
+        >>> adapter = LangGraphAdapter(
+        ...     compiled,
+        ...     input_key="question",
+        ...     answer_keys=["response", "output"],
+        ...     docs_keys=["documents", "context", "retrieved_docs"],
+        ... )
+    """
+
+    def __init__(
+        self,
+        graph: StateGraph[Any] | CompiledStateGraph,
+        *,
+        input_key: str = "question",
+        answer_keys: Sequence[str] | None = None,
+        docs_keys: Sequence[str] | None = None,
+        input_transform: Callable[[str], dict[str, Any]] | None = None,
+        output_transform: Callable[[dict[str, Any]], tuple[str, list[Document]]] | None = None,
+        config: dict[str, Any] | None = None,
+    ) -> None:
+        """Initialize the adapter.
+
+        Args:
+            graph: A LangGraph StateGraph or CompiledStateGraph.
+            input_key: Key to use when passing the question to the graph.
+            answer_keys: Keys to search for the answer in final state.
+                        Defaults to common answer keys.
+            docs_keys: Keys to search for retrieved documents in state.
+                      Defaults to common document keys.
+            input_transform: Optional function to transform the question
+                            into graph input format.
+            output_transform: Optional function to extract (answer, docs)
+                             from final state. If provided, answer_keys
+                             and docs_keys are ignored.
+            config: Optional LangGraph config to pass to invoke/ainvoke.
+        """
+        self._graph = graph
+        self._input_key = input_key
+        self._answer_keys = answer_keys or [
+            "answer",
+            "response",
+            "output",
+            "result",
+            "generation",
+            "messages",
+        ]
+        self._docs_keys = docs_keys or [
+            "documents",
+            "docs",
+            "context",
+            "retrieved_docs",
+            "retrieved_documents",
+            "sources",
+        ]
+        self._input_transform = input_transform
+        self._output_transform = output_transform
+        self._config = config or {}
+
+        # Compile if needed
+        if hasattr(graph, "compile") and not hasattr(graph, "invoke"):
+            self._compiled = graph.compile()
+        else:
+            self._compiled = graph
+
+    @property
+    def graph(self) -> StateGraph[Any] | CompiledStateGraph:
+        """Get the underlying LangGraph graph."""
+        return self._graph
+
+    def _prepare_input(self, question: str) -> dict[str, Any]:
+        """Prepare input for the graph.
+
+        Args:
+            question: The question to process.
+
+        Returns:
+            Input dict for the graph.
+        """
+        if self._input_transform:
+            return self._input_transform(question)
+        return {self._input_key: question}
+
+    def _extract_output(self, state: dict[str, Any]) -> tuple[str, list[Document]]:
+        """Extract answer and documents from final state.
+
+        Args:
+            state: The final graph state.
+
+        Returns:
+            Tuple of (answer, documents).
+        """
+        if self._output_transform:
+            return self._output_transform(state)
+
+        answer = _extract_answer_from_state(state, self._answer_keys)
+        documents = _extract_documents_from_state(state, self._docs_keys)
+
+        return answer, documents
+
+    async def query(self, question: str) -> RAGResponse:
+        """Execute the graph and return response.
+
+        Args:
+            question: The question to answer.
+
+        Returns:
+            RAGResponse with answer and retrieved documents.
+        """
+        graph_input = self._prepare_input(question)
+
+        # LangGraph graphs may be sync or async
+        if hasattr(self._compiled, "ainvoke"):
+            final_state = await self._compiled.ainvoke(graph_input, config=self._config)
+        else:
+            final_state = await asyncio.to_thread(self._compiled.invoke, graph_input, config=self._config)
+
+        answer, documents = self._extract_output(final_state)
+
+        return RAGResponse(
+            answer=answer,
+            retrieved_docs=documents,
+            metadata={
+                "adapter": "langgraph",
+                "final_state_keys": list(final_state.keys()) if isinstance(final_state, dict) else [],
+            },
+        )
+
+
+class LangGraphStreamAdapter(LangGraphAdapter):
+    """Adapter for LangGraph with streaming state updates.
+
+    Extends LangGraphAdapter to capture intermediate states during
+    graph execution. Useful for debugging and tracing.
+
+    Example:
+        >>> adapter = LangGraphStreamAdapter(compiled)
+        >>> response = await adapter.query("What is X?")
+        >>> print(response.metadata["trace"])  # List of state updates
+    """
+
+    async def query(self, question: str) -> RAGResponse:
+        """Execute the graph with streaming and return response.
+
+        Args:
+            question: The question to answer.
+
+        Returns:
+            RAGResponse with answer, documents, and execution trace.
+        """
+        graph_input = self._prepare_input(question)
+        trace: list[dict[str, Any]] = []
+        final_state: dict[str, Any] = {}
+
+        # Stream execution if supported
+        if hasattr(self._compiled, "astream"):
+            async for state_update in self._compiled.astream(graph_input, config=self._config):
+                trace.append({"update": state_update})
+                if isinstance(state_update, dict):
+                    final_state.update(state_update)
+        elif hasattr(self._compiled, "stream"):
+            # Sync stream in thread
+            def run_stream() -> tuple[list[dict[str, Any]], dict[str, Any]]:
+                t: list[dict[str, Any]] = []
+                s: dict[str, Any] = {}
+                for state_update in self._compiled.stream(graph_input, config=self._config):
+                    t.append({"update": state_update})
+                    if isinstance(state_update, dict):
+                        s.update(state_update)
+                return t, s
+
+            trace, final_state = await asyncio.to_thread(run_stream)
+        else:
+            # Fallback to regular invoke
+            if hasattr(self._compiled, "ainvoke"):
+                final_state = await self._compiled.ainvoke(graph_input, config=self._config)
+            else:
+                final_state = await asyncio.to_thread(self._compiled.invoke, graph_input, config=self._config)
+
+        answer, documents = self._extract_output(final_state)
+
+        return RAGResponse(
+            answer=answer,
+            retrieved_docs=documents,
+            metadata={
+                "adapter": "langgraph_stream",
+                "trace": trace,
+                "trace_length": len(trace),
+                "final_state_keys": list(final_state.keys()) if isinstance(final_state, dict) else [],
+            },
+        )

--- a/tests/unit/test_langgraph.py
+++ b/tests/unit/test_langgraph.py
@@ -1,0 +1,586 @@
+"""Unit tests for the LangGraph adapter."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from ragnarok_ai.adapters.frameworks.langgraph import (
+    LangGraphAdapter,
+    LangGraphStreamAdapter,
+    _extract_answer_from_state,
+    _extract_documents_from_state,
+)
+from ragnarok_ai.core.types import Document, RAGResponse
+
+# ============================================================================
+# Mock LangGraph Classes
+# ============================================================================
+
+
+class MockLCDocument:
+    """Mock LangChain Document."""
+
+    def __init__(self, page_content: str, metadata: dict[str, Any] | None = None) -> None:
+        self.page_content = page_content
+        self.metadata = metadata or {}
+
+
+class MockMessage:
+    """Mock LangChain message."""
+
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+
+class MockCompiledGraph:
+    """Mock LangGraph CompiledStateGraph (sync)."""
+
+    def __init__(self, final_state: dict[str, Any]) -> None:
+        self._final_state = final_state
+
+    def invoke(
+        self,
+        _input: dict[str, Any],
+        config: dict[str, Any] | None = None,  # noqa: ARG002
+    ) -> dict[str, Any]:
+        return self._final_state
+
+
+class MockAsyncCompiledGraph:
+    """Mock LangGraph CompiledStateGraph (async)."""
+
+    def __init__(self, final_state: dict[str, Any]) -> None:
+        self._final_state = final_state
+
+    async def ainvoke(
+        self,
+        _input: dict[str, Any],
+        config: dict[str, Any] | None = None,  # noqa: ARG002
+    ) -> dict[str, Any]:
+        return self._final_state
+
+
+class MockStreamingGraph:
+    """Mock LangGraph CompiledStateGraph with streaming (sync)."""
+
+    def __init__(self, states: list[dict[str, Any]]) -> None:
+        self._states = states
+
+    def stream(
+        self,
+        _input: dict[str, Any],
+        config: dict[str, Any] | None = None,  # noqa: ARG002
+    ) -> list[dict[str, Any]]:
+        return self._states
+
+    def invoke(
+        self,
+        _input: dict[str, Any],
+        config: dict[str, Any] | None = None,  # noqa: ARG002
+    ) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for state in self._states:
+            result.update(state)
+        return result
+
+
+class MockAsyncStreamingGraph:
+    """Mock LangGraph CompiledStateGraph with async streaming."""
+
+    def __init__(self, states: list[dict[str, Any]]) -> None:
+        self._states = states
+
+    async def astream(
+        self,
+        _input: dict[str, Any],
+        config: dict[str, Any] | None = None,  # noqa: ARG002
+    ) -> Any:
+        for state in self._states:
+            yield state
+
+    async def ainvoke(
+        self,
+        _input: dict[str, Any],
+        config: dict[str, Any] | None = None,  # noqa: ARG002
+    ) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for state in self._states:
+            result.update(state)
+        return result
+
+
+class MockStateGraph:
+    """Mock LangGraph StateGraph (needs compilation)."""
+
+    def __init__(self, compiled: MockCompiledGraph) -> None:
+        self._compiled = compiled
+
+    def compile(self) -> MockCompiledGraph:
+        return self._compiled
+
+
+# ============================================================================
+# Helper Function Tests
+# ============================================================================
+
+
+class TestExtractDocumentsFromState:
+    """Tests for _extract_documents_from_state."""
+
+    def test_extract_ragnarok_documents(self) -> None:
+        """Test extracting RAGnarok Document objects."""
+        state = {
+            "documents": [
+                Document(id="doc1", content="Content 1"),
+                Document(id="doc2", content="Content 2"),
+            ]
+        }
+        docs = _extract_documents_from_state(state, ["documents"])
+        assert len(docs) == 2
+        assert docs[0].id == "doc1"
+
+    def test_extract_langchain_documents(self) -> None:
+        """Test extracting LangChain Document objects."""
+        state = {
+            "context": [
+                MockLCDocument("Content 1", {"id": "lc1"}),
+                MockLCDocument("Content 2", {"source": "file.txt"}),
+            ]
+        }
+        docs = _extract_documents_from_state(state, ["context"])
+        assert len(docs) == 2
+        assert docs[0].id == "lc1"
+        assert docs[1].id == "file.txt"
+
+    def test_extract_dict_documents(self) -> None:
+        """Test extracting dict-format documents."""
+        state = {
+            "docs": [
+                {"id": "d1", "content": "Content 1"},
+                {"id": "d2", "page_content": "Content 2"},
+            ]
+        }
+        docs = _extract_documents_from_state(state, ["docs"])
+        assert len(docs) == 2
+        assert docs[0].content == "Content 1"
+        assert docs[1].content == "Content 2"
+
+    def test_extract_string_documents(self) -> None:
+        """Test extracting string documents."""
+        state = {"sources": ["Source 1 text", "Source 2 text"]}
+        docs = _extract_documents_from_state(state, ["sources"])
+        assert len(docs) == 2
+        assert docs[0].content == "Source 1 text"
+        assert docs[0].id == "sources_0"
+
+    def test_extract_from_multiple_keys(self) -> None:
+        """Test extracting from multiple state keys."""
+        state = {
+            "documents": [Document(id="doc1", content="C1")],
+            "context": [MockLCDocument("C2", {"id": "doc2"})],
+        }
+        docs = _extract_documents_from_state(state, ["documents", "context"])
+        assert len(docs) == 2
+
+    def test_empty_state(self) -> None:
+        """Test with empty state."""
+        docs = _extract_documents_from_state({}, ["documents"])
+        assert docs == []
+
+    def test_missing_key(self) -> None:
+        """Test with missing key."""
+        state = {"other_key": "value"}
+        docs = _extract_documents_from_state(state, ["documents"])
+        assert docs == []
+
+
+class TestExtractAnswerFromState:
+    """Tests for _extract_answer_from_state."""
+
+    def test_extract_string_answer(self) -> None:
+        """Test extracting string answer."""
+        state = {"answer": "The answer is 42."}
+        answer = _extract_answer_from_state(state, ["answer"])
+        assert answer == "The answer is 42."
+
+    def test_extract_from_messages(self) -> None:
+        """Test extracting from messages list."""
+        state = {"messages": [MockMessage("First"), MockMessage("Final answer")]}
+        answer = _extract_answer_from_state(state, ["messages"])
+        assert answer == "Final answer"
+
+    def test_extract_from_string_list(self) -> None:
+        """Test extracting from string list."""
+        state = {"output": ["Step 1", "Step 2", "Final"]}
+        answer = _extract_answer_from_state(state, ["output"])
+        assert answer == "Final"
+
+    def test_priority_order(self) -> None:
+        """Test that first matching key is used."""
+        state = {
+            "answer": "First answer",
+            "response": "Second response",
+        }
+        answer = _extract_answer_from_state(state, ["answer", "response"])
+        assert answer == "First answer"
+
+    def test_empty_state(self) -> None:
+        """Test with empty state."""
+        answer = _extract_answer_from_state({}, ["answer"])
+        assert answer == ""
+
+    def test_none_value(self) -> None:
+        """Test with None value."""
+        state = {"answer": None, "response": "Fallback"}
+        answer = _extract_answer_from_state(state, ["answer", "response"])
+        assert answer == "Fallback"
+
+
+# ============================================================================
+# LangGraphAdapter Tests
+# ============================================================================
+
+
+class TestLangGraphAdapter:
+    """Tests for LangGraphAdapter."""
+
+    @pytest.mark.asyncio
+    async def test_query_sync_graph(self) -> None:
+        """Test querying with a sync compiled graph."""
+        graph = MockCompiledGraph(
+            {
+                "answer": "The capital is Paris.",
+                "documents": [
+                    Document(id="doc1", content="Paris is the capital of France."),
+                ],
+            }
+        )
+        adapter = LangGraphAdapter(graph)
+
+        response = await adapter.query("What is the capital of France?")
+
+        assert isinstance(response, RAGResponse)
+        assert response.answer == "The capital is Paris."
+        assert len(response.retrieved_docs) == 1
+        assert response.retrieved_docs[0].id == "doc1"
+
+    @pytest.mark.asyncio
+    async def test_query_async_graph(self) -> None:
+        """Test querying with an async compiled graph."""
+        graph = MockAsyncCompiledGraph(
+            {
+                "response": "Async response",
+                "context": [MockLCDocument("Content", {"id": "async_doc"})],
+            }
+        )
+        adapter = LangGraphAdapter(graph)
+
+        response = await adapter.query("Test question")
+
+        assert response.answer == "Async response"
+        assert len(response.retrieved_docs) == 1
+        assert response.retrieved_docs[0].id == "async_doc"
+
+    @pytest.mark.asyncio
+    async def test_query_with_state_graph(self) -> None:
+        """Test querying with an uncompiled StateGraph."""
+        compiled = MockCompiledGraph({"answer": "Compiled answer", "documents": []})
+        graph = MockStateGraph(compiled)
+        adapter = LangGraphAdapter(graph)
+
+        response = await adapter.query("Test")
+
+        assert response.answer == "Compiled answer"
+
+    @pytest.mark.asyncio
+    async def test_custom_input_key(self) -> None:
+        """Test custom input key."""
+
+        class InputCheckGraph:
+            def invoke(
+                self,
+                data: dict[str, Any],
+                config: dict[str, Any] | None = None,  # noqa: ARG002
+            ) -> dict[str, Any]:
+                assert "query" in data
+                return {"answer": "Input OK", "documents": []}
+
+        graph = InputCheckGraph()
+        adapter = LangGraphAdapter(graph, input_key="query")
+
+        response = await adapter.query("Test")
+        assert response.answer == "Input OK"
+
+    @pytest.mark.asyncio
+    async def test_custom_answer_keys(self) -> None:
+        """Test custom answer keys."""
+        graph = MockCompiledGraph(
+            {
+                "generation": "Custom answer key",
+                "documents": [],
+            }
+        )
+        adapter = LangGraphAdapter(graph, answer_keys=["generation"])
+
+        response = await adapter.query("Test")
+        assert response.answer == "Custom answer key"
+
+    @pytest.mark.asyncio
+    async def test_custom_docs_keys(self) -> None:
+        """Test custom docs keys."""
+        graph = MockCompiledGraph(
+            {
+                "answer": "Answer",
+                "retrieved_chunks": [Document(id="chunk1", content="Chunk content")],
+            }
+        )
+        adapter = LangGraphAdapter(graph, docs_keys=["retrieved_chunks"])
+
+        response = await adapter.query("Test")
+        assert len(response.retrieved_docs) == 1
+        assert response.retrieved_docs[0].id == "chunk1"
+
+    @pytest.mark.asyncio
+    async def test_input_transform(self) -> None:
+        """Test custom input transformation."""
+
+        class TransformCheckGraph:
+            def invoke(
+                self,
+                data: dict[str, Any],
+                config: dict[str, Any] | None = None,  # noqa: ARG002
+            ) -> dict[str, Any]:
+                assert data["messages"][0]["role"] == "user"
+                return {"answer": "Transform OK", "documents": []}
+
+        def transform(question: str) -> dict[str, Any]:
+            return {"messages": [{"role": "user", "content": question}]}
+
+        graph = TransformCheckGraph()
+        adapter = LangGraphAdapter(graph, input_transform=transform)
+
+        response = await adapter.query("Test")
+        assert response.answer == "Transform OK"
+
+    @pytest.mark.asyncio
+    async def test_output_transform(self) -> None:
+        """Test custom output transformation."""
+        graph = MockCompiledGraph(
+            {
+                "custom_answer": "Transformed",
+                "custom_docs": [{"id": "t1", "text": "Doc text"}],
+            }
+        )
+
+        def transform(state: dict[str, Any]) -> tuple[str, list[Document]]:
+            return state["custom_answer"], [Document(id=d["id"], content=d["text"]) for d in state["custom_docs"]]
+
+        adapter = LangGraphAdapter(graph, output_transform=transform)
+
+        response = await adapter.query("Test")
+        assert response.answer == "Transformed"
+        assert response.retrieved_docs[0].content == "Doc text"
+
+    @pytest.mark.asyncio
+    async def test_with_config(self) -> None:
+        """Test passing config to graph."""
+
+        class ConfigCheckGraph:
+            def invoke(self, _data: dict[str, Any], config: dict[str, Any] | None = None) -> dict[str, Any]:
+                assert config is not None
+                assert config.get("recursion_limit") == 10
+                return {"answer": "Config OK", "documents": []}
+
+        graph = ConfigCheckGraph()
+        adapter = LangGraphAdapter(graph, config={"recursion_limit": 10})
+
+        response = await adapter.query("Test")
+        assert response.answer == "Config OK"
+
+    def test_graph_property(self) -> None:
+        """Test accessing the underlying graph."""
+        graph = MockCompiledGraph({"answer": "", "documents": []})
+        adapter = LangGraphAdapter(graph)
+        assert adapter.graph is graph
+
+    @pytest.mark.asyncio
+    async def test_metadata_includes_state_keys(self) -> None:
+        """Test that metadata includes final state keys."""
+        graph = MockCompiledGraph(
+            {
+                "answer": "Test",
+                "documents": [],
+                "extra_key": "value",
+            }
+        )
+        adapter = LangGraphAdapter(graph)
+
+        response = await adapter.query("Test")
+        assert "final_state_keys" in response.metadata
+        assert "answer" in response.metadata["final_state_keys"]
+        assert "extra_key" in response.metadata["final_state_keys"]
+
+
+# ============================================================================
+# LangGraphStreamAdapter Tests
+# ============================================================================
+
+
+class TestLangGraphStreamAdapter:
+    """Tests for LangGraphStreamAdapter."""
+
+    @pytest.mark.asyncio
+    async def test_stream_sync_graph(self) -> None:
+        """Test streaming with sync graph."""
+        states = [
+            {"step": "retrieve", "documents": [Document(id="d1", content="C1")]},
+            {"step": "generate", "answer": "Final answer"},
+        ]
+        graph = MockStreamingGraph(states)
+        adapter = LangGraphStreamAdapter(graph)
+
+        response = await adapter.query("Test")
+
+        assert response.answer == "Final answer"
+        assert "trace" in response.metadata
+        assert response.metadata["trace_length"] == 2
+
+    @pytest.mark.asyncio
+    async def test_stream_async_graph(self) -> None:
+        """Test streaming with async graph."""
+        states = [
+            {"documents": [MockLCDocument("Doc content", {"id": "ad1"})]},
+            {"answer": "Async streamed answer"},
+        ]
+        graph = MockAsyncStreamingGraph(states)
+        adapter = LangGraphStreamAdapter(graph)
+
+        response = await adapter.query("Test")
+
+        assert response.answer == "Async streamed answer"
+        assert response.metadata["trace_length"] == 2
+
+    @pytest.mark.asyncio
+    async def test_stream_captures_trace(self) -> None:
+        """Test that streaming captures state trace."""
+        states = [
+            {"step": 1, "status": "retrieving"},
+            {"step": 2, "status": "generating"},
+            {"step": 3, "answer": "Done"},
+        ]
+        graph = MockStreamingGraph(states)
+        adapter = LangGraphStreamAdapter(graph)
+
+        response = await adapter.query("Test")
+
+        trace = response.metadata["trace"]
+        assert len(trace) == 3
+        assert trace[0]["update"]["step"] == 1
+
+    @pytest.mark.asyncio
+    async def test_fallback_to_invoke(self) -> None:
+        """Test fallback to invoke when stream not available."""
+        graph = MockCompiledGraph(
+            {
+                "answer": "Fallback answer",
+                "documents": [],
+            }
+        )
+        adapter = LangGraphStreamAdapter(graph)
+
+        response = await adapter.query("Test")
+
+        assert response.answer == "Fallback answer"
+        # No trace when using fallback
+        assert response.metadata.get("trace", []) == []
+
+
+# ============================================================================
+# Protocol Compliance Tests
+# ============================================================================
+
+
+class TestProtocolCompliance:
+    """Tests for RAGProtocol compliance."""
+
+    @pytest.mark.asyncio
+    async def test_adapter_implements_protocol(self) -> None:
+        """Test that LangGraphAdapter implements RAGProtocol."""
+        from ragnarok_ai.core.protocols import RAGProtocol
+
+        graph = MockCompiledGraph({"answer": "", "documents": []})
+        adapter = LangGraphAdapter(graph)
+
+        assert hasattr(adapter, "query")
+        assert callable(adapter.query)
+        assert isinstance(adapter, RAGProtocol)
+
+    @pytest.mark.asyncio
+    async def test_stream_adapter_implements_protocol(self) -> None:
+        """Test that LangGraphStreamAdapter implements RAGProtocol."""
+        from ragnarok_ai.core.protocols import RAGProtocol
+
+        graph = MockCompiledGraph({"answer": "", "documents": []})
+        adapter = LangGraphStreamAdapter(graph)
+
+        assert isinstance(adapter, RAGProtocol)
+
+
+# ============================================================================
+# Integration with Evaluate Tests
+# ============================================================================
+
+
+class TestEvaluateIntegration:
+    """Tests for integration with evaluate function."""
+
+    @pytest.mark.asyncio
+    async def test_evaluate_with_langgraph_adapter(self) -> None:
+        """Test using LangGraph adapter with evaluate."""
+        from ragnarok_ai.core.evaluate import evaluate
+        from ragnarok_ai.core.types import Query, TestSet
+
+        graph = MockCompiledGraph(
+            {
+                "answer": "Paris is the capital of France.",
+                "documents": [Document(id="doc1", content="France info")],
+            }
+        )
+        adapter = LangGraphAdapter(graph)
+
+        testset = TestSet(
+            queries=[
+                Query(text="What is the capital of France?", ground_truth_docs=["doc1"]),
+            ]
+        )
+
+        result = await evaluate(adapter, testset)
+
+        assert result is not None
+        assert len(result.responses) == 1
+        assert "Paris" in result.responses[0]
+
+    @pytest.mark.asyncio
+    async def test_evaluate_with_stream_adapter(self) -> None:
+        """Test using stream adapter with evaluate."""
+        from ragnarok_ai.core.evaluate import evaluate
+        from ragnarok_ai.core.types import Query, TestSet
+
+        states = [
+            {"documents": [Document(id="doc1", content="Relevant")]},
+            {"answer": "Streamed answer"},
+        ]
+        graph = MockStreamingGraph(states)
+        adapter = LangGraphStreamAdapter(graph)
+
+        testset = TestSet(
+            queries=[
+                Query(text="Test?", ground_truth_docs=["doc1"]),
+            ]
+        )
+
+        result = await evaluate(adapter, testset)
+
+        assert len(result.responses) == 1


### PR DESCRIPTION
## Summary

- Add `LangGraphAdapter` for evaluating LangGraph `StateGraph` and `CompiledStateGraph`
- Add `LangGraphStreamAdapter` for streaming with execution trace capture
- Support multiple document formats (RAGnarok, LangChain, dict, string)
- Custom input/output transforms for flexible integration
- Full `RAGProtocol` compliance

## Test plan

- [x] 32 unit tests covering adapters and helper functions
- [x] Protocol compliance tests
- [x] Integration tests with evaluate function
- [x] Lint and type check pass