### PR TITLE
feat(telemetry): add OpenTelemetry integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,14 @@ langchain = [
 cli = [
     "typer>=0.9",
 ]
+telemetry = [
+    "opentelemetry-api>=1.20",
+    "opentelemetry-sdk>=1.20",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.20",
+    "opentelemetry-exporter-otlp-proto-http>=1.20",
+]
 all = [
-    "ragnarok-ai[ollama,qdrant,langchain,cli]",
+    "ragnarok-ai[ollama,qdrant,langchain,cli,telemetry]",
 ]
 
 [project.scripts]
@@ -153,6 +159,10 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = ["yaml", "yaml.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["opentelemetry", "opentelemetry.*"]
 ignore_missing_imports = true
 
 # ============================================================================

--- a/src/ragnarok_ai/core/evaluate.py
+++ b/src/ragnarok_ai/core/evaluate.py
@@ -1,6 +1,12 @@
+"""Evaluation module for RAG pipelines.
+
+This module provides functions to evaluate RAG pipelines against test sets.
+"""
+
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import time
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -8,6 +14,7 @@ if TYPE_CHECKING:
     from ragnarok_ai.core.protocols import RAGProtocol
     from ragnarok_ai.core.types import Query, TestSet
     from ragnarok_ai.evaluators.retrieval import RetrievalMetrics
+    from ragnarok_ai.telemetry.tracer import RAGTracer
 
 
 class EvaluationResult:
@@ -41,6 +48,7 @@ async def evaluate(
     testset: TestSet,
     *,
     k: int = 10,
+    tracer: RAGTracer | None = None,
 ) -> EvaluationResult:
     """Evaluate a RAG pipeline against a test set.
 
@@ -48,14 +56,27 @@ async def evaluate(
         rag_pipeline: RAG pipeline implementing RAGProtocol.
         testset: Test set of queries with ground truth.
         k: Number of top results to consider for @K metrics.
+        tracer: Optional RAGTracer for OpenTelemetry tracing.
 
     Returns:
         EvaluationResult containing metrics and responses.
+
+    Example:
+        >>> from ragnarok_ai import evaluate
+        >>> from ragnarok_ai.telemetry import RAGTracer, OTLPExporter
+        >>>
+        >>> # Without tracing
+        >>> result = await evaluate(rag_pipeline, testset)
+        >>>
+        >>> # With tracing
+        >>> exporter = OTLPExporter(endpoint="http://localhost:4317")
+        >>> tracer = RAGTracer(exporter=exporter.get_span_exporter())
+        >>> result = await evaluate(rag_pipeline, testset, tracer=tracer)
     """
     metrics: list[RetrievalMetrics] = []
     responses: list[str] = []
 
-    async for _, metric, answer in evaluate_stream(rag_pipeline, testset, k=k):
+    async for _, metric, answer in evaluate_stream(rag_pipeline, testset, k=k, tracer=tracer):
         metrics.append(metric)
         responses.append(answer)
 
@@ -67,6 +88,7 @@ async def evaluate_stream(
     testset: TestSet,
     *,
     k: int = 10,
+    tracer: RAGTracer | None = None,
 ) -> AsyncIterator[tuple[Query, RetrievalMetrics, str]]:
     """Evaluate a RAG pipeline against a test set, yielding results as they complete.
 
@@ -74,6 +96,7 @@ async def evaluate_stream(
         rag_pipeline: RAG pipeline implementing RAGProtocol.
         testset: Test set of queries with ground truth.
         k: Number of top results to consider for @K metrics.
+        tracer: Optional RAGTracer for OpenTelemetry tracing.
 
     Yields:
         Tuples of (query, metrics, response) for each query.
@@ -84,20 +107,67 @@ async def evaluate_stream(
     from ragnarok_ai.core.exceptions import EvaluationError
     from ragnarok_ai.core.types import RetrievalResult
     from ragnarok_ai.evaluators.retrieval import evaluate_retrieval
+    from ragnarok_ai.telemetry.tracer import NoOpTracer
 
-    for query in testset:
-        try:
-            response = await rag_pipeline.query(query.text)
-        except Exception as e:
-            raise EvaluationError(f"Failed to query pipeline for '{query.text}': {e}") from e
+    # Use provided tracer or no-op
+    active_tracer = tracer if tracer is not None else NoOpTracer()
 
-        try:
-            retrieval_result = RetrievalResult(
-                query=query,
-                retrieved_docs=response.retrieved_docs,
-            )
-            metric = evaluate_retrieval(retrieval_result, k=k)
-        except Exception as e:
-            raise EvaluationError(f"Failed to calculate metrics for '{query.text}': {e}") from e
+    with active_tracer.start_span(
+        "evaluate",
+        attributes={
+            "ragnarok.num_queries": len(testset.queries),
+            "ragnarok.k": k,
+        },
+    ) as eval_span:
+        for i, query in enumerate(testset):
+            query_attrs: dict[str, Any] = {
+                "ragnarok.query_index": i,
+                "ragnarok.query_text": query.text[:200],  # Truncate for safety
+                "ragnarok.num_ground_truth_docs": len(query.ground_truth_docs),
+            }
 
-        yield query, metric, response.answer
+            with active_tracer.start_span(f"query_{i}", attributes=query_attrs) as query_span:
+                # RAG query
+                with active_tracer.start_span("rag_query") as rag_span:
+                    start_time = time.perf_counter()
+                    try:
+                        response = await rag_pipeline.query(query.text)
+                    except Exception as e:
+                        raise EvaluationError(f"Failed to query pipeline for '{query.text}': {e}") from e
+                    query_latency = time.perf_counter() - start_time
+
+                    rag_span.set_attribute("ragnarok.latency_ms", query_latency * 1000)
+                    rag_span.set_attribute("ragnarok.num_retrieved_docs", len(response.retrieved_docs))
+                    rag_span.set_attribute(
+                        "ragnarok.retrieved_doc_ids",
+                        [doc.id for doc in response.retrieved_docs[:10]],  # Limit to first 10
+                    )
+                    rag_span.set_attribute("ragnarok.answer_length", len(response.answer))
+
+                # Metrics calculation
+                with active_tracer.start_span("evaluate_metrics") as metrics_span:
+                    start_time = time.perf_counter()
+                    try:
+                        retrieval_result = RetrievalResult(
+                            query=query,
+                            retrieved_docs=response.retrieved_docs,
+                        )
+                        metric = evaluate_retrieval(retrieval_result, k=k)
+                    except Exception as e:
+                        raise EvaluationError(f"Failed to calculate metrics for '{query.text}': {e}") from e
+                    metrics_latency = time.perf_counter() - start_time
+
+                    metrics_span.set_attribute("ragnarok.latency_ms", metrics_latency * 1000)
+                    metrics_span.set_attribute("ragnarok.precision", metric.precision)
+                    metrics_span.set_attribute("ragnarok.recall", metric.recall)
+                    metrics_span.set_attribute("ragnarok.mrr", metric.mrr)
+                    metrics_span.set_attribute("ragnarok.ndcg", metric.ndcg)
+
+                # Update query span with results
+                query_span.set_attribute("ragnarok.precision", metric.precision)
+                query_span.set_attribute("ragnarok.recall", metric.recall)
+
+            yield query, metric, response.answer
+
+        # Set evaluation-level attributes
+        eval_span.set_attribute("ragnarok.completed", True)

--- a/src/ragnarok_ai/telemetry/__init__.py
+++ b/src/ragnarok_ai/telemetry/__init__.py
@@ -1,0 +1,24 @@
+"""Telemetry module for ragnarok-ai.
+
+This module provides OpenTelemetry integration for tracing RAG evaluations.
+"""
+
+from __future__ import annotations
+
+from ragnarok_ai.telemetry.exporters import (
+    OTLPExporter,
+    create_otlp_exporter,
+)
+from ragnarok_ai.telemetry.tracer import (
+    RAGTracer,
+    get_tracer,
+    set_tracer,
+)
+
+__all__ = [
+    "OTLPExporter",
+    "RAGTracer",
+    "create_otlp_exporter",
+    "get_tracer",
+    "set_tracer",
+]

--- a/src/ragnarok_ai/telemetry/exporters.py
+++ b/src/ragnarok_ai/telemetry/exporters.py
@@ -1,0 +1,156 @@
+"""OpenTelemetry exporters for ragnarok-ai.
+
+This module provides OTLP exporters for sending traces to
+OpenTelemetry-compatible backends like Jaeger, Phoenix, or Grafana Tempo.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+
+class OTLPExporter:
+    """OTLP exporter configuration.
+
+    Wraps OpenTelemetry OTLP exporters for both gRPC and HTTP protocols.
+
+    Example:
+        >>> exporter = OTLPExporter(endpoint="http://localhost:4317")
+        >>> tracer = RAGTracer(exporter=exporter.get_span_exporter())
+
+        >>> # HTTP exporter
+        >>> exporter = OTLPExporter(
+        ...     endpoint="http://localhost:4318/v1/traces",
+        ...     protocol="http",
+        ... )
+    """
+
+    def __init__(
+        self,
+        endpoint: str = "http://localhost:4317",
+        *,
+        protocol: Literal["grpc", "http"] = "grpc",
+        headers: dict[str, str] | None = None,
+        timeout: int = 30,
+        insecure: bool = True,
+    ) -> None:
+        """Initialize the OTLP exporter.
+
+        Args:
+            endpoint: OTLP collector endpoint.
+                     Default gRPC: http://localhost:4317
+                     Default HTTP: http://localhost:4318/v1/traces
+            protocol: Protocol to use ("grpc" or "http").
+            headers: Optional headers to send with requests.
+            timeout: Request timeout in seconds.
+            insecure: Whether to use insecure connection (no TLS).
+        """
+        self._endpoint = endpoint
+        self._protocol = protocol
+        self._headers = headers or {}
+        self._timeout = timeout
+        self._insecure = insecure
+        self._exporter: Any = None
+
+    @property
+    def endpoint(self) -> str:
+        """Get the configured endpoint."""
+        return self._endpoint
+
+    @property
+    def protocol(self) -> str:
+        """Get the configured protocol."""
+        return self._protocol
+
+    def get_span_exporter(self) -> Any:
+        """Get the OpenTelemetry span exporter.
+
+        Returns:
+            Configured OTLP span exporter.
+
+        Raises:
+            ImportError: If required OpenTelemetry packages are not installed.
+        """
+        if self._exporter is not None:
+            return self._exporter
+
+        if self._protocol == "grpc":
+            self._exporter = self._create_grpc_exporter()
+        else:
+            self._exporter = self._create_http_exporter()
+
+        return self._exporter
+
+    def _create_grpc_exporter(self) -> Any:
+        """Create a gRPC OTLP exporter."""
+        try:
+            from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+                OTLPSpanExporter,
+            )
+        except ImportError as e:
+            raise ImportError(
+                "opentelemetry-exporter-otlp-proto-grpc is required for gRPC export. "
+                "Install with: pip install ragnarok-ai[telemetry]"
+            ) from e
+
+        return OTLPSpanExporter(
+            endpoint=self._endpoint,
+            headers=self._headers or None,
+            timeout=self._timeout,
+            insecure=self._insecure,
+        )
+
+    def _create_http_exporter(self) -> Any:
+        """Create an HTTP OTLP exporter."""
+        try:
+            from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+                OTLPSpanExporter,
+            )
+        except ImportError as e:
+            raise ImportError(
+                "opentelemetry-exporter-otlp-proto-http is required for HTTP export. "
+                "Install with: pip install ragnarok-ai[telemetry]"
+            ) from e
+
+        return OTLPSpanExporter(
+            endpoint=self._endpoint,
+            headers=self._headers or None,
+            timeout=self._timeout,
+        )
+
+
+def create_otlp_exporter(
+    endpoint: str = "http://localhost:4317",
+    *,
+    protocol: Literal["grpc", "http"] = "grpc",
+    headers: dict[str, str] | None = None,
+    timeout: int = 30,
+    insecure: bool = True,
+) -> OTLPExporter:
+    """Create an OTLP exporter.
+
+    Convenience function for creating an OTLP exporter.
+
+    Args:
+        endpoint: OTLP collector endpoint.
+        protocol: Protocol to use ("grpc" or "http").
+        headers: Optional headers to send with requests.
+        timeout: Request timeout in seconds.
+        insecure: Whether to use insecure connection (no TLS).
+
+    Returns:
+        Configured OTLPExporter.
+
+    Example:
+        >>> exporter = create_otlp_exporter("http://localhost:4317")
+        >>> # Use with RAGTracer
+        >>> from ragnarok_ai.telemetry import RAGTracer
+        >>> tracer = RAGTracer(exporter=exporter.get_span_exporter())
+    """
+    return OTLPExporter(
+        endpoint=endpoint,
+        protocol=protocol,
+        headers=headers,
+        timeout=timeout,
+        insecure=insecure,
+    )

--- a/src/ragnarok_ai/telemetry/tracer.py
+++ b/src/ragnarok_ai/telemetry/tracer.py
@@ -1,0 +1,239 @@
+"""Core tracer implementation for ragnarok-ai.
+
+This module provides a tracer abstraction that wraps OpenTelemetry
+for tracing RAG evaluation steps.
+"""
+
+from __future__ import annotations
+
+import time
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+# Global tracer instance
+_tracer: RAGTracer | None = None
+
+
+class SpanContext:
+    """Context manager for a tracing span."""
+
+    def __init__(
+        self,
+        name: str,
+        tracer: RAGTracer,
+        attributes: dict[str, Any] | None = None,
+    ) -> None:
+        self._name = name
+        self._tracer = tracer
+        self._attributes = attributes or {}
+        self._start_time: float = 0
+        self._span: Any = None
+
+    def set_attribute(self, key: str, value: Any) -> None:
+        """Set an attribute on the span."""
+        self._attributes[key] = value
+        if self._span is not None and hasattr(self._span, "set_attribute"):
+            self._span.set_attribute(key, _normalize_attribute(value))
+
+    def set_status_ok(self) -> None:
+        """Mark the span as successful."""
+        if self._span is not None and hasattr(self._span, "set_status"):
+            try:
+                from opentelemetry.trace import StatusCode
+
+                self._span.set_status(StatusCode.OK)
+            except ImportError:
+                pass
+
+    def set_status_error(self, message: str) -> None:
+        """Mark the span as errored."""
+        if self._span is not None and hasattr(self._span, "set_status"):
+            try:
+                from opentelemetry.trace import StatusCode
+
+                self._span.set_status(StatusCode.ERROR, message)
+            except ImportError:
+                pass
+
+    def record_exception(self, exception: BaseException) -> None:
+        """Record an exception on the span."""
+        if self._span is not None and hasattr(self._span, "record_exception"):
+            self._span.record_exception(exception)
+
+
+class RAGTracer:
+    """Tracer for RAG evaluation operations.
+
+    Provides a high-level interface for tracing RAG operations
+    with OpenTelemetry. Falls back to no-op if OpenTelemetry
+    is not installed.
+
+    Example:
+        >>> tracer = RAGTracer(service_name="my-rag-eval")
+        >>> with tracer.start_span("evaluate") as span:
+        ...     span.set_attribute("num_queries", 10)
+        ...     # evaluation logic
+    """
+
+    def __init__(
+        self,
+        service_name: str = "ragnarok-ai",
+        *,
+        exporter: Any | None = None,
+    ) -> None:
+        """Initialize the tracer.
+
+        Args:
+            service_name: Name of the service for traces.
+            exporter: Optional OpenTelemetry span exporter.
+        """
+        self._service_name = service_name
+        self._exporter = exporter
+        self._otel_tracer: Any = None
+        self._provider: Any = None
+        self._enabled = False
+
+        self._setup_tracer()
+
+    def _setup_tracer(self) -> None:
+        """Set up OpenTelemetry tracer if available."""
+        try:
+            from opentelemetry import trace
+            from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+            from opentelemetry.sdk.trace import TracerProvider
+
+            resource = Resource(attributes={SERVICE_NAME: self._service_name})
+            self._provider = TracerProvider(resource=resource)
+
+            if self._exporter is not None:
+                from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+                self._provider.add_span_processor(BatchSpanProcessor(self._exporter))
+
+            trace.set_tracer_provider(self._provider)
+            self._otel_tracer = trace.get_tracer(self._service_name)
+            self._enabled = True
+        except ImportError:
+            self._enabled = False
+
+    @property
+    def enabled(self) -> bool:
+        """Check if tracing is enabled."""
+        return self._enabled
+
+    @contextmanager
+    def start_span(
+        self,
+        name: str,
+        attributes: dict[str, Any] | None = None,
+    ) -> Generator[SpanContext, None, None]:
+        """Start a new span.
+
+        Args:
+            name: Name of the span.
+            attributes: Initial attributes for the span.
+
+        Yields:
+            SpanContext for the span.
+        """
+        ctx = SpanContext(name, self, attributes)
+        ctx._start_time = time.perf_counter()
+
+        if self._enabled and self._otel_tracer is not None:
+            with self._otel_tracer.start_as_current_span(name) as span:
+                ctx._span = span
+                if attributes:
+                    for key, value in attributes.items():
+                        span.set_attribute(key, _normalize_attribute(value))
+                try:
+                    yield ctx
+                except Exception as e:
+                    ctx.record_exception(e)
+                    ctx.set_status_error(str(e))
+                    raise
+                else:
+                    ctx.set_status_ok()
+        else:
+            yield ctx
+
+    def shutdown(self) -> None:
+        """Shutdown the tracer and flush pending spans."""
+        if self._provider is not None and hasattr(self._provider, "shutdown"):
+            self._provider.shutdown()
+
+
+class NoOpTracer(RAGTracer):
+    """No-op tracer that does nothing.
+
+    Used when telemetry is disabled or OpenTelemetry is not installed.
+    """
+
+    def __init__(self) -> None:
+        """Initialize without setting up OpenTelemetry."""
+        self._service_name = "noop"
+        self._exporter = None
+        self._otel_tracer = None
+        self._provider = None
+        self._enabled = False
+
+    def _setup_tracer(self) -> None:
+        """No-op setup."""
+        pass
+
+    @contextmanager
+    def start_span(
+        self,
+        name: str,
+        attributes: dict[str, Any] | None = None,
+    ) -> Generator[SpanContext, None, None]:
+        """No-op span context."""
+        yield SpanContext(name, self, attributes)
+
+    def shutdown(self) -> None:
+        """No-op shutdown."""
+        pass
+
+
+def _normalize_attribute(value: Any) -> Any:
+    """Normalize a value for OpenTelemetry attributes.
+
+    OpenTelemetry only supports primitive types and lists of primitives.
+
+    Args:
+        value: Value to normalize.
+
+    Returns:
+        Normalized value suitable for OpenTelemetry.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, bool | int | float | str):
+        return value
+    if isinstance(value, list):
+        return [_normalize_attribute(v) for v in value]
+    return str(value)
+
+
+def get_tracer() -> RAGTracer:
+    """Get the global tracer instance.
+
+    Returns:
+        The global RAGTracer, or a NoOpTracer if not set.
+    """
+    global _tracer
+    if _tracer is None:
+        return NoOpTracer()
+    return _tracer
+
+
+def set_tracer(tracer: RAGTracer | None) -> None:
+    """Set the global tracer instance.
+
+    Args:
+        tracer: The tracer to use globally, or None to disable.
+    """
+    global _tracer
+    _tracer = tracer

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -1,0 +1,415 @@
+"""Unit tests for the telemetry module."""
+
+from __future__ import annotations
+
+import pytest
+
+from ragnarok_ai.core.types import Document, RAGResponse
+from ragnarok_ai.telemetry.exporters import OTLPExporter, create_otlp_exporter
+from ragnarok_ai.telemetry.tracer import (
+    NoOpTracer,
+    RAGTracer,
+    SpanContext,
+    _normalize_attribute,
+    get_tracer,
+    set_tracer,
+)
+
+# ============================================================================
+# SpanContext Tests
+# ============================================================================
+
+
+class TestSpanContext:
+    """Tests for SpanContext."""
+
+    def test_set_attribute(self) -> None:
+        """Test setting attributes on span context."""
+        tracer = NoOpTracer()
+        ctx = SpanContext("test", tracer)
+        ctx.set_attribute("key", "value")
+        assert ctx._attributes["key"] == "value"
+
+    def test_set_multiple_attributes(self) -> None:
+        """Test setting multiple attributes."""
+        tracer = NoOpTracer()
+        ctx = SpanContext("test", tracer, {"initial": "attr"})
+        ctx.set_attribute("key1", "value1")
+        ctx.set_attribute("key2", 42)
+        assert ctx._attributes["initial"] == "attr"
+        assert ctx._attributes["key1"] == "value1"
+        assert ctx._attributes["key2"] == 42
+
+    def test_set_status_ok_no_span(self) -> None:
+        """Test set_status_ok with no span (no-op)."""
+        tracer = NoOpTracer()
+        ctx = SpanContext("test", tracer)
+        # Should not raise
+        ctx.set_status_ok()
+
+    def test_set_status_error_no_span(self) -> None:
+        """Test set_status_error with no span (no-op)."""
+        tracer = NoOpTracer()
+        ctx = SpanContext("test", tracer)
+        # Should not raise
+        ctx.set_status_error("error message")
+
+    def test_record_exception_no_span(self) -> None:
+        """Test record_exception with no span (no-op)."""
+        tracer = NoOpTracer()
+        ctx = SpanContext("test", tracer)
+        # Should not raise
+        ctx.record_exception(ValueError("test error"))
+
+
+# ============================================================================
+# NoOpTracer Tests
+# ============================================================================
+
+
+class TestNoOpTracer:
+    """Tests for NoOpTracer."""
+
+    def test_init(self) -> None:
+        """Test NoOpTracer initialization."""
+        tracer = NoOpTracer()
+        assert tracer._service_name == "noop"
+        assert not tracer.enabled
+
+    def test_start_span(self) -> None:
+        """Test starting a span with NoOpTracer."""
+        tracer = NoOpTracer()
+        with tracer.start_span("test_span") as span:
+            assert isinstance(span, SpanContext)
+            span.set_attribute("key", "value")
+
+    def test_start_span_with_attributes(self) -> None:
+        """Test starting a span with initial attributes."""
+        tracer = NoOpTracer()
+        with tracer.start_span("test_span", attributes={"key": "value"}) as span:
+            assert span._attributes["key"] == "value"
+
+    def test_shutdown(self) -> None:
+        """Test NoOpTracer shutdown (no-op)."""
+        tracer = NoOpTracer()
+        tracer.shutdown()  # Should not raise
+
+    def test_nested_spans(self) -> None:
+        """Test nested spans with NoOpTracer."""
+        tracer = NoOpTracer()
+        with tracer.start_span("parent") as parent:
+            parent.set_attribute("level", "parent")
+            with tracer.start_span("child") as child:
+                child.set_attribute("level", "child")
+                assert child._attributes["level"] == "child"
+            assert parent._attributes["level"] == "parent"
+
+
+# ============================================================================
+# RAGTracer Tests
+# ============================================================================
+
+
+class TestRAGTracer:
+    """Tests for RAGTracer."""
+
+    def test_init_without_otel(self) -> None:
+        """Test RAGTracer initialization without OpenTelemetry."""
+        # This test checks that RAGTracer gracefully handles missing OTel
+        tracer = RAGTracer(service_name="test-service")
+        # enabled depends on whether OTel is installed
+        assert tracer._service_name == "test-service"
+
+    def test_start_span_without_otel(self) -> None:
+        """Test starting a span without OpenTelemetry."""
+        tracer = RAGTracer(service_name="test-service")
+        with tracer.start_span("test_span") as span:
+            assert isinstance(span, SpanContext)
+            span.set_attribute("key", "value")
+
+    def test_shutdown(self) -> None:
+        """Test RAGTracer shutdown."""
+        tracer = RAGTracer(service_name="test-service")
+        tracer.shutdown()  # Should not raise
+
+
+# ============================================================================
+# Global Tracer Tests
+# ============================================================================
+
+
+class TestGlobalTracer:
+    """Tests for global tracer functions."""
+
+    def test_get_tracer_returns_noop_when_not_set(self) -> None:
+        """Test get_tracer returns NoOpTracer when not set."""
+        set_tracer(None)
+        tracer = get_tracer()
+        assert isinstance(tracer, NoOpTracer)
+
+    def test_set_and_get_tracer(self) -> None:
+        """Test setting and getting global tracer."""
+        custom_tracer = RAGTracer(service_name="custom")
+        set_tracer(custom_tracer)
+        try:
+            assert get_tracer() is custom_tracer
+        finally:
+            set_tracer(None)
+
+    def test_set_tracer_to_none(self) -> None:
+        """Test setting tracer to None."""
+        custom_tracer = RAGTracer(service_name="custom")
+        set_tracer(custom_tracer)
+        set_tracer(None)
+        tracer = get_tracer()
+        assert isinstance(tracer, NoOpTracer)
+
+
+# ============================================================================
+# Attribute Normalization Tests
+# ============================================================================
+
+
+class TestNormalizeAttribute:
+    """Tests for _normalize_attribute."""
+
+    def test_normalize_none(self) -> None:
+        """Test normalizing None."""
+        assert _normalize_attribute(None) == ""
+
+    def test_normalize_string(self) -> None:
+        """Test normalizing string."""
+        assert _normalize_attribute("test") == "test"
+
+    def test_normalize_int(self) -> None:
+        """Test normalizing int."""
+        assert _normalize_attribute(42) == 42
+
+    def test_normalize_float(self) -> None:
+        """Test normalizing float."""
+        assert _normalize_attribute(3.14) == 3.14
+
+    def test_normalize_bool(self) -> None:
+        """Test normalizing bool."""
+        assert _normalize_attribute(True) is True
+        assert _normalize_attribute(False) is False
+
+    def test_normalize_list(self) -> None:
+        """Test normalizing list."""
+        result = _normalize_attribute([1, "two", 3.0])
+        assert result == [1, "two", 3.0]
+
+    def test_normalize_object(self) -> None:
+        """Test normalizing complex object."""
+        obj = {"key": "value"}
+        assert _normalize_attribute(obj) == "{'key': 'value'}"
+
+    def test_normalize_nested_list(self) -> None:
+        """Test normalizing nested list."""
+        result = _normalize_attribute([1, [2, 3], "four"])
+        assert result == [1, [2, 3], "four"]
+
+
+# ============================================================================
+# OTLPExporter Tests
+# ============================================================================
+
+
+class TestOTLPExporter:
+    """Tests for OTLPExporter."""
+
+    def test_init_defaults(self) -> None:
+        """Test OTLPExporter with default values."""
+        exporter = OTLPExporter()
+        assert exporter.endpoint == "http://localhost:4317"
+        assert exporter.protocol == "grpc"
+
+    def test_init_custom_endpoint(self) -> None:
+        """Test OTLPExporter with custom endpoint."""
+        exporter = OTLPExporter(endpoint="http://custom:4317")
+        assert exporter.endpoint == "http://custom:4317"
+
+    def test_init_http_protocol(self) -> None:
+        """Test OTLPExporter with HTTP protocol."""
+        exporter = OTLPExporter(
+            endpoint="http://localhost:4318/v1/traces",
+            protocol="http",
+        )
+        assert exporter.protocol == "http"
+
+    def test_init_with_headers(self) -> None:
+        """Test OTLPExporter with custom headers."""
+        exporter = OTLPExporter(headers={"Authorization": "Bearer token"})
+        assert exporter._headers == {"Authorization": "Bearer token"}
+
+    def test_get_span_exporter_grpc_without_package(self) -> None:
+        """Test getting gRPC exporter without package installed."""
+        exporter = OTLPExporter(protocol="grpc")
+        # This may or may not raise depending on whether OTel is installed
+        try:
+            exporter.get_span_exporter()
+        except ImportError as e:
+            assert "opentelemetry-exporter-otlp-proto-grpc" in str(e)
+
+    def test_get_span_exporter_http_without_package(self) -> None:
+        """Test getting HTTP exporter without package installed."""
+        exporter = OTLPExporter(protocol="http")
+        try:
+            exporter.get_span_exporter()
+        except ImportError as e:
+            assert "opentelemetry-exporter-otlp-proto-http" in str(e)
+
+
+class TestCreateOTLPExporter:
+    """Tests for create_otlp_exporter factory function."""
+
+    def test_create_with_defaults(self) -> None:
+        """Test creating exporter with defaults."""
+        exporter = create_otlp_exporter()
+        assert isinstance(exporter, OTLPExporter)
+        assert exporter.endpoint == "http://localhost:4317"
+
+    def test_create_with_custom_options(self) -> None:
+        """Test creating exporter with custom options."""
+        exporter = create_otlp_exporter(
+            endpoint="http://custom:4317",
+            protocol="http",
+            headers={"X-Custom": "header"},
+            timeout=60,
+            insecure=False,
+        )
+        assert exporter.endpoint == "http://custom:4317"
+        assert exporter.protocol == "http"
+        assert exporter._headers == {"X-Custom": "header"}
+        assert exporter._timeout == 60
+        assert exporter._insecure is False
+
+
+# ============================================================================
+# Integration with Evaluate Tests
+# ============================================================================
+
+
+class MockRAGPipeline:
+    """Mock RAG pipeline for testing."""
+
+    def __init__(self, response: RAGResponse) -> None:
+        self._response = response
+
+    async def query(self, question: str) -> RAGResponse:  # noqa: ARG002
+        return self._response
+
+
+class TestEvaluateWithTelemetry:
+    """Tests for evaluate function with telemetry."""
+
+    @pytest.mark.asyncio
+    async def test_evaluate_with_noop_tracer(self) -> None:
+        """Test evaluate with NoOpTracer."""
+        from ragnarok_ai.core.evaluate import evaluate
+        from ragnarok_ai.core.types import Query, TestSet
+
+        pipeline = MockRAGPipeline(
+            RAGResponse(
+                answer="Paris",
+                retrieved_docs=[Document(id="doc1", content="France info")],
+            )
+        )
+        testset = TestSet(queries=[Query(text="What is the capital?", ground_truth_docs=["doc1"])])
+
+        tracer = NoOpTracer()
+        result = await evaluate(pipeline, testset, tracer=tracer)
+
+        assert result is not None
+        assert len(result.responses) == 1
+
+    @pytest.mark.asyncio
+    async def test_evaluate_with_rag_tracer(self) -> None:
+        """Test evaluate with RAGTracer (OTel may or may not be installed)."""
+        from ragnarok_ai.core.evaluate import evaluate
+        from ragnarok_ai.core.types import Query, TestSet
+
+        pipeline = MockRAGPipeline(
+            RAGResponse(
+                answer="Paris",
+                retrieved_docs=[Document(id="doc1", content="France info")],
+            )
+        )
+        testset = TestSet(queries=[Query(text="What is the capital?", ground_truth_docs=["doc1"])])
+
+        tracer = RAGTracer(service_name="test-eval")
+        result = await evaluate(pipeline, testset, tracer=tracer)
+
+        assert result is not None
+        assert len(result.responses) == 1
+        tracer.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_evaluate_without_tracer(self) -> None:
+        """Test evaluate without tracer (uses NoOpTracer internally)."""
+        from ragnarok_ai.core.evaluate import evaluate
+        from ragnarok_ai.core.types import Query, TestSet
+
+        pipeline = MockRAGPipeline(
+            RAGResponse(
+                answer="Paris",
+                retrieved_docs=[Document(id="doc1", content="France info")],
+            )
+        )
+        testset = TestSet(queries=[Query(text="What is the capital?", ground_truth_docs=["doc1"])])
+
+        result = await evaluate(pipeline, testset)
+
+        assert result is not None
+        assert len(result.responses) == 1
+
+    @pytest.mark.asyncio
+    async def test_evaluate_stream_with_tracer(self) -> None:
+        """Test evaluate_stream with tracer."""
+        from ragnarok_ai.core.evaluate import evaluate_stream
+        from ragnarok_ai.core.types import Query, TestSet
+
+        pipeline = MockRAGPipeline(
+            RAGResponse(
+                answer="Paris",
+                retrieved_docs=[Document(id="doc1", content="France info")],
+            )
+        )
+        testset = TestSet(
+            queries=[
+                Query(text="Q1?", ground_truth_docs=["doc1"]),
+                Query(text="Q2?", ground_truth_docs=["doc1"]),
+            ]
+        )
+
+        tracer = NoOpTracer()
+        results = []
+        async for query, metric, answer in evaluate_stream(pipeline, testset, tracer=tracer):
+            results.append((query, metric, answer))
+
+        assert len(results) == 2
+
+
+# ============================================================================
+# Module Import Tests
+# ============================================================================
+
+
+class TestModuleImports:
+    """Tests for module imports."""
+
+    def test_import_from_telemetry(self) -> None:
+        """Test importing from telemetry module."""
+        from ragnarok_ai.telemetry import (
+            OTLPExporter,
+            RAGTracer,
+            create_otlp_exporter,
+            get_tracer,
+            set_tracer,
+        )
+
+        assert OTLPExporter is not None
+        assert RAGTracer is not None
+        assert create_otlp_exporter is not None
+        assert get_tracer is not None
+        assert set_tracer is not None

--- a/uv.lock
+++ b/uv.lock
@@ -650,6 +650,18 @@ wheels = [
 ]
 
 [[package]]
+name = "googleapis-common-protos"
+version = "1.72.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e5/7b/adfd75544c415c487b33061fe7ae526165241c1ea133f9a9125a56b39fd8/googleapis_common_protos-1.72.0.tar.gz", hash = "sha256:e55a601c1b32b52d7a3e65f43563e2aa61bcd737998ee672ac9b951cd49319f5", size = 147433 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/ab/09169d5a4612a5f92490806649ac8d41e3ec9129c636754575b3553f4ea4/googleapis_common_protos-1.72.0-py3-none-any.whl", hash = "sha256:4299c5a82d5ae1a9702ada957347726b167f9f8d1fc352477702a1e851ff4038", size = 297515 },
+]
+
+[[package]]
 name = "greenlet"
 version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -868,6 +880,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008 },
+]
+
+[[package]]
+name = "importlib-metadata"
+version = "8.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865 },
 ]
 
 [[package]]
@@ -1592,6 +1616,106 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/33/9b/9dd6e2db8d49eb24f86acaaa5258e5f4c8ed38209a4ee9de2d1a0ca25045/numpy-2.4.1-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2023ef86243690c2791fd6353e5b4848eedaa88ca8a2d129f462049f6d484696", size = 14538937 },
     { url = "https://files.pythonhosted.org/packages/53/87/d5bd995b0f798a37105b876350d346eea5838bd8f77ea3d7a48392f3812b/numpy-2.4.1-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8361ea4220d763e54cff2fbe7d8c93526b744f7cd9ddab47afeff7e14e8503be", size = 16479830 },
     { url = "https://files.pythonhosted.org/packages/5b/c7/b801bf98514b6ae6475e941ac05c58e6411dd863ea92916bfd6d510b08c1/numpy-2.4.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:4f1b68ff47680c2925f8063402a693ede215f0257f02596b1318ecdfb1d79e33", size = 12492579 },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.39.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/97/b9/3161be15bb8e3ad01be8be5a968a9237c3027c5be504362ff800fca3e442/opentelemetry_api-1.39.1.tar.gz", hash = "sha256:fbde8c80e1b937a2c61f20347e91c0c18a1940cecf012d62e65a7caf08967c9c", size = 65767 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/df/d3f1ddf4bb4cb50ed9b1139cc7b1c54c34a1e7ce8fd1b9a37c0d1551a6bd/opentelemetry_api-1.39.1-py3-none-any.whl", hash = "sha256:2edd8463432a7f8443edce90972169b195e7d6a05500cd29e6d13898187c9950", size = 66356 },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.39.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/9d/22d241b66f7bbde88a3bfa6847a351d2c46b84de23e71222c6aae25c7050/opentelemetry_exporter_otlp_proto_common-1.39.1.tar.gz", hash = "sha256:763370d4737a59741c89a67b50f9e39271639ee4afc999dadfe768541c027464", size = 20409 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/02/ffc3e143d89a27ac21fd557365b98bd0653b98de8a101151d5805b5d4c33/opentelemetry_exporter_otlp_proto_common-1.39.1-py3-none-any.whl", hash = "sha256:08f8a5862d64cc3435105686d0216c1365dc5701f86844a8cd56597d0c764fde", size = 18366 },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-grpc"
+version = "1.39.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/48/b329fed2c610c2c32c9366d9dc597202c9d1e58e631c137ba15248d8850f/opentelemetry_exporter_otlp_proto_grpc-1.39.1.tar.gz", hash = "sha256:772eb1c9287485d625e4dbe9c879898e5253fea111d9181140f51291b5fec3ad", size = 24650 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/a3/cc9b66575bd6597b98b886a2067eea2693408d2d5f39dad9ab7fc264f5f3/opentelemetry_exporter_otlp_proto_grpc-1.39.1-py3-none-any.whl", hash = "sha256:fa1c136a05c7e9b4c09f739469cbdb927ea20b34088ab1d959a849b5cc589c18", size = 19766 },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.39.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/80/04/2a08fa9c0214ae38880df01e8bfae12b067ec0793446578575e5080d6545/opentelemetry_exporter_otlp_proto_http-1.39.1.tar.gz", hash = "sha256:31bdab9745c709ce90a49a0624c2bd445d31a28ba34275951a6a362d16a0b9cb", size = 17288 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/f1/b27d3e2e003cd9a3592c43d099d2ed8d0a947c15281bf8463a256db0b46c/opentelemetry_exporter_otlp_proto_http-1.39.1-py3-none-any.whl", hash = "sha256:d9f5207183dd752a412c4cd564ca8875ececba13be6e9c6c370ffb752fd59985", size = 19641 },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.39.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/1d/f25d76d8260c156c40c97c9ed4511ec0f9ce353f8108ca6e7561f82a06b2/opentelemetry_proto-1.39.1.tar.gz", hash = "sha256:6c8e05144fc0d3ed4d22c2289c6b126e03bcd0e6a7da0f16cedd2e1c2772e2c8", size = 46152 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/95/b40c96a7b5203005a0b03d8ce8cd212ff23f1793d5ba289c87a097571b18/opentelemetry_proto-1.39.1-py3-none-any.whl", hash = "sha256:22cdc78efd3b3765d09e68bfbd010d4fc254c9818afd0b6b423387d9dee46007", size = 72535 },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.39.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/fb/c76080c9ba07e1e8235d24cdcc4d125ef7aa3edf23eb4e497c2e50889adc/opentelemetry_sdk-1.39.1.tar.gz", hash = "sha256:cf4d4563caf7bff906c9f7967e2be22d0d6b349b908be0d90fb21c8e9c995cc6", size = 171460 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/98/e91cf858f203d86f4eccdf763dcf01cf03f1dae80c3750f7e635bfa206b6/opentelemetry_sdk-1.39.1-py3-none-any.whl", hash = "sha256:4d5482c478513ecb0a5d938dcc61394e647066e0cc2676bee9f3af3f3f45f01c", size = 132565 },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.60b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/df/553f93ed38bf22f4b999d9be9c185adb558982214f33eae539d3b5cd0858/opentelemetry_semantic_conventions-0.60b1.tar.gz", hash = "sha256:87c228b5a0669b748c76d76df6c364c369c28f1c465e50f661e39737e84bc953", size = 137935 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/5e/5958555e09635d09b75de3c4f8b9cae7335ca545d77392ffe7331534c402/opentelemetry_semantic_conventions-0.60b1-py3-none-any.whl", hash = "sha256:9fa8c8b0c110da289809292b0591220d3a7b53c1526a23021e977d68597893fb", size = 219982 },
 ]
 
 [[package]]
@@ -2340,6 +2464,10 @@ all = [
     { name = "httpx" },
     { name = "langchain" },
     { name = "langchain-community" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
     { name = "qdrant-client" },
     { name = "typer" },
 ]
@@ -2368,6 +2496,12 @@ ollama = [
 qdrant = [
     { name = "qdrant-client" },
 ]
+telemetry = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -2376,6 +2510,10 @@ requires-dist = [
     { name = "langchain", marker = "extra == 'langchain'", specifier = ">=0.1" },
     { name = "langchain-community", marker = "extra == 'langchain'", specifier = ">=0.0.10" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8" },
+    { name = "opentelemetry-api", marker = "extra == 'telemetry'", specifier = ">=1.20" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc", marker = "extra == 'telemetry'", specifier = ">=1.20" },
+    { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'telemetry'", specifier = ">=1.20" },
+    { name = "opentelemetry-sdk", marker = "extra == 'telemetry'", specifier = ">=1.20" },
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.7" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.6" },
     { name = "pydantic", specifier = ">=2.0" },
@@ -2385,13 +2523,13 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "qdrant-client", marker = "extra == 'qdrant'", specifier = ">=1.7" },
-    { name = "ragnarok-ai", extras = ["ollama", "qdrant", "langchain", "cli"], marker = "extra == 'all'" },
+    { name = "ragnarok-ai", extras = ["ollama", "qdrant", "langchain", "cli", "telemetry"], marker = "extra == 'all'" },
     { name = "respx", marker = "extra == 'dev'", specifier = ">=0.20" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.3" },
     { name = "typer", marker = "extra == 'cli'", specifier = ">=0.9" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
 ]
-provides-extras = ["dev", "ollama", "qdrant", "langchain", "cli", "all"]
+provides-extras = ["dev", "ollama", "qdrant", "langchain", "cli", "telemetry", "all"]
 
 [[package]]
 name = "requests"
@@ -2970,6 +3108,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/86/0f0dccb6e59a9e7f122c5afd43568b1d31b8ab7dda5f1b01fb5c7025c9a9/yarl-1.22.0-cp314-cp314t-win_amd64.whl", hash = "sha256:9fb17ea16e972c63d25d4a97f016d235c78dd2344820eb35bc034bc32012ee27", size = 96292 },
     { url = "https://files.pythonhosted.org/packages/48/b7/503c98092fb3b344a179579f55814b613c1fbb1c23b3ec14a7b008a66a6e/yarl-1.22.0-cp314-cp314t-win_arm64.whl", hash = "sha256:9f6d73c1436b934e3f01df1e1b21ff765cd1d28c77dfb9ace207f746d4610ee1", size = 85171 },
     { url = "https://files.pythonhosted.org/packages/73/ae/b48f95715333080afb75a4504487cbe142cae1268afc482d06692d605ae6/yarl-1.22.0-py3-none-any.whl", hash = "sha256:1380560bdba02b6b6c90de54133c81c9f2a453dee9912fe58c1dcced1edb7cff", size = 46814 },
+]
+
+[[package]]
+name = "zipp"
+version = "3.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add `RAGTracer` for OpenTelemetry tracing with graceful fallback
- Add `OTLPExporter` for gRPC and HTTP protocols
- Integrate tracing into `evaluate()` with spans for each step:
  - `evaluate` (root span)
  - `query_N` (per-query span)
  - `rag_query` (RAG pipeline call)
  - `evaluate_metrics` (metrics calculation)
- Compatible with Phoenix, Jaeger, Grafana Tempo

## Test plan

- [x] 37 unit tests covering tracer, exporters, and integration
- [x] Tests work with and without OpenTelemetry installed
- [x] Lint and type check pass

## Usage

```python
from ragnarok_ai import evaluate
from ragnarok_ai.telemetry import RAGTracer, OTLPExporter

exporter = OTLPExporter(endpoint="http://localhost:4317")
tracer = RAGTracer(exporter=exporter.get_span_exporter())

result = await evaluate(rag_pipeline, testset, tracer=tracer)
```

Closes #16