### PR TITLE
feat(adapters): add ReAct and Chain-of-Thought adapters

### DIFF
--- a/src/ragnarok_ai/adapters/__init__.py
+++ b/src/ragnarok_ai/adapters/__init__.py
@@ -12,6 +12,11 @@ Adapter Classification:
 
 from __future__ import annotations
 
+from ragnarok_ai.adapters.agents import (
+    ChainOfThoughtAdapter,
+    ReActAdapter,
+    ReActParser,
+)
 from ragnarok_ai.adapters.frameworks import (
     DSPyModuleAdapter,
     DSPyRAGAdapter,
@@ -41,6 +46,7 @@ __all__ = [
     "LOCAL_LLM_ADAPTERS",
     "LOCAL_VECTORSTORE_ADAPTERS",
     "AnthropicLLM",
+    "ChainOfThoughtAdapter",
     "ChromaVectorStore",
     "DSPyModuleAdapter",
     "DSPyRAGAdapter",
@@ -56,5 +62,7 @@ __all__ = [
     "OllamaLLM",
     "OpenAILLM",
     "QdrantVectorStore",
+    "ReActAdapter",
+    "ReActParser",
     "VLLMAdapter",
 ]

--- a/src/ragnarok_ai/adapters/agents/__init__.py
+++ b/src/ragnarok_ai/adapters/agents/__init__.py
@@ -1,0 +1,28 @@
+"""Agent adapters for ragnarok-ai.
+
+This module provides adapters for common agent patterns:
+- ReAct (Reason + Act)
+- Chain-of-Thought (CoT)
+
+Example:
+    >>> from ragnarok_ai.adapters.agents import ReActParser, ReActAdapter
+    >>>
+    >>> # Parse ReAct output
+    >>> parser = ReActParser()
+    >>> steps = parser.parse(raw_output)
+    >>>
+    >>> # Wrap a ReAct agent
+    >>> adapter = ReActAdapter(my_agent)
+    >>> response = await adapter.query("What is X?")
+"""
+
+from __future__ import annotations
+
+from ragnarok_ai.adapters.agents.cot import ChainOfThoughtAdapter
+from ragnarok_ai.adapters.agents.react import ReActAdapter, ReActParser
+
+__all__ = [
+    "ChainOfThoughtAdapter",
+    "ReActAdapter",
+    "ReActParser",
+]

--- a/src/ragnarok_ai/adapters/agents/cot.py
+++ b/src/ragnarok_ai/adapters/agents/cot.py
@@ -1,0 +1,246 @@
+"""Chain-of-Thought adapter for agent evaluation.
+
+This module provides an adapter for evaluating Chain-of-Thought reasoning.
+
+Example:
+    >>> from ragnarok_ai.adapters.agents import ChainOfThoughtAdapter
+    >>>
+    >>> adapter = ChainOfThoughtAdapter(llm)
+    >>> response = await adapter.query("What is 2+2*3?")
+    >>> print(response.reasoning_trace)
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+from ragnarok_ai.agents.types import AgentResponse, AgentStep
+
+if TYPE_CHECKING:
+    from ragnarok_ai.core.protocols import LLMProtocol
+
+
+class ChainOfThoughtAdapter:
+    """Wrap an LLM for Chain-of-Thought evaluation.
+
+    Prompts the LLM to reason step by step and parses the response
+    into structured AgentSteps.
+
+    Attributes:
+        llm: The LLM provider.
+        cot_prompt: Prompt to trigger step-by-step reasoning.
+        step_separator: String used to separate reasoning steps.
+
+    Example:
+        >>> adapter = ChainOfThoughtAdapter(
+        ...     llm,
+        ...     cot_prompt="Let's solve this step by step:",
+        ... )
+        >>> response = await adapter.query("What is 15% of 80?")
+        >>> for step in response.steps:
+        ...     print(f"{step.step_type}: {step.content[:50]}...")
+    """
+
+    def __init__(
+        self,
+        llm: LLMProtocol,
+        cot_prompt: str = "Let's think step by step.",
+        step_separator: str = "\n\n",
+        answer_prefix: str | None = None,
+    ) -> None:
+        """Initialize the adapter.
+
+        Args:
+            llm: LLM provider implementing LLMProtocol.
+            cot_prompt: Prompt appended to trigger CoT reasoning.
+            step_separator: String that separates reasoning steps.
+            answer_prefix: Optional prefix that marks the final answer.
+                          If found, content after it becomes the answer.
+        """
+        self.llm = llm
+        self.cot_prompt = cot_prompt
+        self.step_separator = step_separator
+        self.answer_prefix = answer_prefix
+
+    async def query(self, question: str) -> AgentResponse:
+        """Execute Chain-of-Thought reasoning and return response.
+
+        Args:
+            question: The question to reason about.
+
+        Returns:
+            AgentResponse with thought steps and final answer.
+        """
+        start_time = time.perf_counter()
+
+        # Build prompt with CoT trigger
+        prompt = f"{question}\n\n{self.cot_prompt}"
+
+        # Generate response
+        raw_response = await self.llm.generate(prompt)
+
+        elapsed_ms = (time.perf_counter() - start_time) * 1000
+
+        # Parse into steps
+        steps, answer = self._parse_cot_response(raw_response)
+
+        return AgentResponse(
+            answer=answer,
+            steps=steps,
+            total_latency_ms=elapsed_ms,
+            metadata={
+                "adapter": "chain_of_thought",
+                "cot_prompt": self.cot_prompt,
+                "raw_response_length": len(raw_response),
+            },
+        )
+
+    def _parse_cot_response(self, response: str) -> tuple[list[AgentStep], str]:
+        """Parse CoT response into thought steps.
+
+        Args:
+            response: Raw LLM response.
+
+        Returns:
+            Tuple of (list of AgentSteps, final answer).
+        """
+        if not response or not response.strip():
+            return [], ""
+
+        # Check for explicit answer prefix
+        answer = ""
+        reasoning_text = response
+
+        if self.answer_prefix:
+            prefix_lower = self.answer_prefix.lower()
+            response_lower = response.lower()
+            if prefix_lower in response_lower:
+                idx = response_lower.find(prefix_lower)
+                reasoning_text = response[:idx]
+                answer = response[idx + len(self.answer_prefix) :].strip()
+
+        # Split into paragraphs/steps
+        if self.step_separator in reasoning_text:
+            paragraphs = reasoning_text.split(self.step_separator)
+        else:
+            # Fallback: split by numbered steps or sentences
+            paragraphs = self._split_into_steps(reasoning_text)
+
+        steps: list[AgentStep] = []
+        for i, paragraph in enumerate(paragraphs):
+            paragraph = paragraph.strip()
+            if not paragraph:
+                continue
+
+            # If no explicit answer and this is the last paragraph
+            is_last = i == len(paragraphs) - 1
+            if is_last and not answer:
+                # Check if this looks like a conclusion
+                if self._looks_like_conclusion(paragraph):
+                    answer = self._extract_answer_from_conclusion(paragraph)
+                    steps.append(AgentStep(step_type="final_answer", content=paragraph))
+                else:
+                    answer = paragraph
+                    steps.append(AgentStep(step_type="final_answer", content=paragraph))
+            else:
+                steps.append(AgentStep(step_type="thought", content=paragraph))
+
+        # If still no answer, use last step content
+        if not answer and steps:
+            answer = steps[-1].content
+
+        return steps, answer
+
+    def _split_into_steps(self, text: str) -> list[str]:
+        """Split text into steps when no clear separator.
+
+        Args:
+            text: Text to split.
+
+        Returns:
+            List of step strings.
+        """
+        # Try to split by numbered steps (1. 2. 3. or Step 1: Step 2:)
+        numbered_pattern = r"(?:^|\n)\s*(?:\d+[.):]|Step\s+\d+[.:])"
+        import re
+
+        parts = re.split(numbered_pattern, text, flags=re.IGNORECASE)
+
+        # Filter empty parts
+        parts = [p.strip() for p in parts if p.strip()]
+
+        if len(parts) > 1:
+            return parts
+
+        # Fallback: split by sentence boundaries for long responses
+        if len(text) > 200:
+            sentences = re.split(r"(?<=[.!?])\s+", text)
+            # Group sentences into chunks of ~2-3 sentences
+            chunks: list[str] = []
+            current_chunk: list[str] = []
+            for sentence in sentences:
+                current_chunk.append(sentence)
+                if len(current_chunk) >= 2:
+                    chunks.append(" ".join(current_chunk))
+                    current_chunk = []
+            if current_chunk:
+                chunks.append(" ".join(current_chunk))
+            if len(chunks) > 1:
+                return chunks
+
+        # Return as single step
+        return [text]
+
+    def _looks_like_conclusion(self, text: str) -> bool:
+        """Check if text looks like a conclusion/answer.
+
+        Args:
+            text: Text to check.
+
+        Returns:
+            True if text appears to be a conclusion.
+        """
+        conclusion_indicators = [
+            "therefore",
+            "thus",
+            "so the answer",
+            "the answer is",
+            "in conclusion",
+            "finally",
+            "hence",
+            "the result is",
+            "we get",
+            "this gives us",
+            "equals",
+            "=",
+        ]
+        text_lower = text.lower()
+        return any(indicator in text_lower for indicator in conclusion_indicators)
+
+    def _extract_answer_from_conclusion(self, text: str) -> str:
+        """Extract the actual answer from a conclusion paragraph.
+
+        Args:
+            text: Conclusion text.
+
+        Returns:
+            Extracted answer.
+        """
+        import re
+
+        # Look for patterns like "the answer is X" or "= X"
+        patterns = [
+            r"(?:the\s+)?answer\s+is[:\s]+(.+?)(?:\.|$)",
+            r"(?:equals?|=)\s*(.+?)(?:\.|$)",
+            r"result\s+is[:\s]+(.+?)(?:\.|$)",
+            r"we\s+get[:\s]+(.+?)(?:\.|$)",
+        ]
+
+        for pattern in patterns:
+            match = re.search(pattern, text, re.IGNORECASE)
+            if match:
+                return match.group(1).strip()
+
+        # Return the whole text as answer
+        return text

--- a/src/ragnarok_ai/adapters/agents/react.py
+++ b/src/ragnarok_ai/adapters/agents/react.py
@@ -1,0 +1,459 @@
+"""ReAct pattern parser and adapter for agent evaluation.
+
+This module provides tools to parse and evaluate ReAct-style agent outputs.
+
+ReAct Format:
+    Thought: I need to find information about X
+    Action: search
+    Action Input: {"query": "X"}
+    Observation: [search results]
+    Thought: Based on the results...
+    Action: answer
+    Action Input: {"response": "Y"}
+
+Example:
+    >>> from ragnarok_ai.adapters.agents import ReActParser, ReActAdapter
+    >>>
+    >>> # Parse raw output
+    >>> parser = ReActParser()
+    >>> steps = parser.parse(raw_output)
+    >>>
+    >>> # Wrap a ReAct agent
+    >>> adapter = ReActAdapter(my_agent)
+    >>> response = await adapter.query("What is X?")
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import time
+from typing import TYPE_CHECKING, Any
+
+from ragnarok_ai.agents.types import AgentResponse, AgentStep, ToolCall
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+
+def _parse_action_input(raw_input: str) -> dict[str, Any]:
+    """Parse action input string to dictionary.
+
+    Handles various formats:
+    - Valid JSON: {"query": "test"}
+    - JSON with single quotes: {'query': 'test'}
+    - Simple string: test query
+
+    Args:
+        raw_input: Raw action input string.
+
+    Returns:
+        Parsed dictionary. If parsing fails, returns {"raw": raw_input}.
+    """
+    raw_input = raw_input.strip()
+
+    if not raw_input:
+        return {}
+
+    # Try standard JSON first
+    try:
+        result = json.loads(raw_input)
+        if isinstance(result, dict):
+            return result
+        return {"value": result}
+    except json.JSONDecodeError:
+        pass
+
+    # Try replacing single quotes with double quotes (Python dict style)
+    try:
+        # Replace single quotes, being careful with apostrophes
+        converted = re.sub(r"'([^']*)':", r'"\1":', raw_input)
+        converted = re.sub(r":\s*'([^']*)'", r': "\1"', converted)
+        result = json.loads(converted)
+        if isinstance(result, dict):
+            return result
+        return {"value": result}
+    except json.JSONDecodeError:
+        pass
+
+    # Try extracting key-value pairs with regex
+    # Pattern: key: value or key=value
+    kv_pattern = r'(\w+)\s*[:=]\s*["\']?([^"\',:}]+)["\']?'
+    matches = re.findall(kv_pattern, raw_input)
+    if matches:
+        return {k.strip(): v.strip() for k, v in matches}
+
+    # Fallback: treat as raw string
+    return {"raw": raw_input}
+
+
+class ReActParser:
+    """Parse ReAct-style text output to structured AgentStep list.
+
+    Supports customizable prefixes for thought, action, action input,
+    and observation sections.
+
+    Attributes:
+        thought_prefix: Prefix for thought lines.
+        action_prefix: Prefix for action lines.
+        action_input_prefix: Prefix for action input lines.
+        observation_prefix: Prefix for observation lines.
+
+    Example:
+        >>> parser = ReActParser()
+        >>> steps = parser.parse('''
+        ... Thought: I need to search
+        ... Action: search
+        ... Action Input: {"query": "test"}
+        ... Observation: Found results
+        ... ''')
+        >>> len(steps)
+        3
+    """
+
+    def __init__(
+        self,
+        thought_prefix: str = "Thought:",
+        action_prefix: str = "Action:",
+        action_input_prefix: str = "Action Input:",
+        observation_prefix: str = "Observation:",
+        final_answer_prefix: str = "Final Answer:",
+    ) -> None:
+        """Initialize the parser.
+
+        Args:
+            thought_prefix: Prefix identifying thought lines.
+            action_prefix: Prefix identifying action lines.
+            action_input_prefix: Prefix identifying action input lines.
+            observation_prefix: Prefix identifying observation lines.
+            final_answer_prefix: Prefix identifying final answer lines.
+        """
+        self.thought_prefix = thought_prefix
+        self.action_prefix = action_prefix
+        self.action_input_prefix = action_input_prefix
+        self.observation_prefix = observation_prefix
+        self.final_answer_prefix = final_answer_prefix
+
+    def parse(self, text: str) -> list[AgentStep]:
+        """Parse ReAct trace into structured steps.
+
+        Args:
+            text: Raw ReAct-style output text.
+
+        Returns:
+            List of AgentStep objects representing the trace.
+        """
+        if not text or not text.strip():
+            return []
+
+        steps: list[AgentStep] = []
+        lines = text.split("\n")
+
+        current_thought: str | None = None
+        current_action: str | None = None
+        current_action_input: str | None = None
+        collecting_observation = False
+        observation_lines: list[str] = []
+
+        i = 0
+        while i < len(lines):
+            line = lines[i]
+            stripped = line.strip()
+
+            # Check for Final Answer
+            if stripped.startswith(self.final_answer_prefix):
+                # Flush pending observation
+                if collecting_observation and observation_lines:
+                    obs_content = "\n".join(observation_lines).strip()
+                    if obs_content:
+                        steps.append(AgentStep(step_type="observation", content=obs_content))
+                        self._update_last_tool_output(steps, obs_content)
+                    observation_lines = []
+                    collecting_observation = False
+
+                # Flush pending thought
+                if current_thought:
+                    steps.append(AgentStep(step_type="thought", content=current_thought))
+                    current_thought = None
+
+                answer = stripped[len(self.final_answer_prefix) :].strip()
+                # Collect multiline final answer
+                i += 1
+                while i < len(lines) and not self._is_prefix_line(lines[i]):
+                    answer += "\n" + lines[i]
+                    i += 1
+                steps.append(AgentStep(step_type="final_answer", content=answer.strip()))
+                continue
+
+            # Check for Thought
+            if stripped.startswith(self.thought_prefix):
+                # Flush pending observation
+                if collecting_observation:
+                    steps.append(AgentStep(step_type="observation", content="\n".join(observation_lines).strip()))
+                    observation_lines = []
+                    collecting_observation = False
+
+                # Flush pending thought
+                if current_thought:
+                    steps.append(AgentStep(step_type="thought", content=current_thought))
+
+                current_thought = stripped[len(self.thought_prefix) :].strip()
+                i += 1
+                continue
+
+            # Check for Action (but not Action Input)
+            if stripped.startswith(self.action_prefix) and not stripped.startswith(self.action_input_prefix):
+                # Flush pending observation
+                if collecting_observation:
+                    steps.append(AgentStep(step_type="observation", content="\n".join(observation_lines).strip()))
+                    observation_lines = []
+                    collecting_observation = False
+
+                current_action = stripped[len(self.action_prefix) :].strip()
+                i += 1
+                continue
+
+            # Check for Action Input
+            if stripped.startswith(self.action_input_prefix):
+                current_action_input = stripped[len(self.action_input_prefix) :].strip()
+
+                # Collect multiline input (for JSON that spans lines)
+                i += 1
+                while i < len(lines) and not self._is_prefix_line(lines[i]):
+                    next_line = lines[i].strip()
+                    if next_line:
+                        current_action_input += " " + next_line
+                    i += 1
+
+                # Create action step with tool call
+                if current_action:
+                    # Flush pending thought first
+                    if current_thought:
+                        steps.append(AgentStep(step_type="thought", content=current_thought))
+                        current_thought = None
+
+                    parsed_input = _parse_action_input(current_action_input or "")
+                    steps.append(
+                        AgentStep(
+                            step_type="action",
+                            content=current_action,
+                            tool_call=ToolCall(
+                                name=current_action,
+                                input=parsed_input,
+                                output="",  # Will be filled by observation
+                            ),
+                        )
+                    )
+                    current_action = None
+                    current_action_input = None
+                continue
+
+            # Check for Observation
+            if stripped.startswith(self.observation_prefix):
+                observation_content = stripped[len(self.observation_prefix) :].strip()
+                observation_lines = [observation_content] if observation_content else []
+                collecting_observation = True
+                i += 1
+                continue
+
+            # Collecting multiline observation
+            if collecting_observation:
+                observation_lines.append(line)
+                i += 1
+                continue
+
+            i += 1
+
+        # Flush remaining items
+        if collecting_observation and observation_lines:
+            obs_content = "\n".join(observation_lines).strip()
+            if obs_content:
+                steps.append(AgentStep(step_type="observation", content=obs_content))
+                # Update last action's tool call output
+                self._update_last_tool_output(steps, obs_content)
+
+        if current_thought:
+            steps.append(AgentStep(step_type="thought", content=current_thought))
+
+        return steps
+
+    def _is_prefix_line(self, line: str) -> bool:
+        """Check if line starts with any known prefix."""
+        stripped = line.strip()
+        return any(
+            stripped.startswith(p)
+            for p in [
+                self.thought_prefix,
+                self.action_prefix,
+                self.observation_prefix,
+                self.final_answer_prefix,
+            ]
+        )
+
+    def _update_last_tool_output(self, steps: list[AgentStep], output: str) -> None:
+        """Update the output of the last tool call in steps."""
+        for i in range(len(steps) - 1, -1, -1):
+            old_tc = steps[i].tool_call
+            if old_tc is not None:
+                # Create new ToolCall with updated output (ToolCall is frozen)
+                new_tc = ToolCall(
+                    name=old_tc.name,
+                    input=old_tc.input,
+                    output=output,
+                    error=old_tc.error,
+                    latency_ms=old_tc.latency_ms,
+                )
+                # Create new AgentStep with updated tool_call (AgentStep is frozen)
+                steps[i] = AgentStep(
+                    step_type=steps[i].step_type,
+                    content=steps[i].content,
+                    tool_call=new_tc,
+                    latency_ms=steps[i].latency_ms,
+                    metadata=steps[i].metadata,
+                )
+                break
+
+    def parse_to_response(
+        self,
+        text: str,
+        answer: str | None = None,
+    ) -> AgentResponse:
+        """Parse ReAct trace and wrap in AgentResponse.
+
+        Args:
+            text: Raw ReAct-style output text.
+            answer: Optional explicit answer. If not provided, extracts
+                   from Final Answer step or last observation.
+
+        Returns:
+            AgentResponse with parsed steps.
+        """
+        steps = self.parse(text)
+
+        # Extract answer if not provided
+        if answer is None:
+            answer = self._extract_answer(steps, text)
+
+        return AgentResponse(
+            answer=answer,
+            steps=steps,
+        )
+
+    def _extract_answer(self, steps: list[AgentStep], raw_text: str) -> str:
+        """Extract answer from steps or raw text.
+
+        Args:
+            steps: Parsed steps.
+            raw_text: Original raw text.
+
+        Returns:
+            Extracted answer string.
+        """
+        # Look for final_answer step
+        for step in reversed(steps):
+            if step.step_type == "final_answer":
+                return step.content
+
+        # Look for last observation
+        for step in reversed(steps):
+            if step.step_type == "observation":
+                return step.content
+
+        # Look for answer action
+        for step in reversed(steps):
+            if (
+                step.tool_call
+                and step.tool_call.name.lower() in ("answer", "respond", "reply")
+                and step.tool_call.input
+            ):
+                return str(step.tool_call.input.get("response", step.tool_call.input.get("raw", "")))
+
+        # Fallback: return last non-empty line
+        for line in reversed(raw_text.split("\n")):
+            if line.strip():
+                return line.strip()
+
+        return ""
+
+
+class ReActAdapter:
+    """Wrap a ReAct-style agent for evaluation.
+
+    Executes the agent and parses its output into structured AgentResponse.
+
+    Attributes:
+        agent: The wrapped agent callable.
+        parser: ReActParser instance for parsing output.
+
+    Example:
+        >>> async def my_agent(question: str) -> str:
+        ...     return '''
+        ...     Thought: I need to search
+        ...     Action: search
+        ...     Action Input: {"q": "test"}
+        ...     Observation: Found it
+        ...     Final Answer: The answer is X
+        ...     '''
+        >>>
+        >>> adapter = ReActAdapter(my_agent)
+        >>> response = await adapter.query("What is X?")
+        >>> print(response.answer)
+        The answer is X
+    """
+
+    def __init__(
+        self,
+        agent: Callable[[str], Awaitable[str]] | Callable[[str], str],
+        parser: ReActParser | None = None,
+        extract_answer: Callable[[str], str] | None = None,
+    ) -> None:
+        """Initialize the adapter.
+
+        Args:
+            agent: Agent callable that takes a question and returns output.
+                  Can be sync or async.
+            parser: Optional custom ReActParser. Uses default if not provided.
+            extract_answer: Optional function to extract answer from raw output.
+        """
+        self.agent = agent
+        self.parser = parser or ReActParser()
+        self.extract_answer = extract_answer
+
+    async def query(self, question: str) -> AgentResponse:
+        """Execute agent and return structured response.
+
+        Args:
+            question: The question to ask the agent.
+
+        Returns:
+            AgentResponse with parsed trajectory.
+        """
+        start_time = time.perf_counter()
+
+        # Execute agent (handle sync/async)
+        if asyncio.iscoroutinefunction(self.agent):
+            raw_output = await self.agent(question)
+        else:
+            raw_output = await asyncio.to_thread(self.agent, question)
+
+        elapsed_ms = (time.perf_counter() - start_time) * 1000
+
+        # Extract answer if custom extractor provided
+        answer = None
+        if self.extract_answer:
+            answer = self.extract_answer(raw_output)
+
+        # Parse output
+        response = self.parser.parse_to_response(raw_output, answer=answer)
+
+        # Update latency
+        return AgentResponse(
+            answer=response.answer,
+            steps=response.steps,
+            total_latency_ms=elapsed_ms,
+            metadata={
+                "adapter": "react",
+                "raw_output_length": len(raw_output),
+            },
+        )

--- a/tests/unit/test_react_cot_adapters.py
+++ b/tests/unit/test_react_cot_adapters.py
@@ -1,0 +1,523 @@
+"""Unit tests for ReAct and CoT adapters."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ragnarok_ai.adapters.agents import ChainOfThoughtAdapter, ReActAdapter, ReActParser
+
+# =============================================================================
+# ReActParser Tests
+# =============================================================================
+
+
+class TestReActParser:
+    """Tests for ReActParser."""
+
+    def test_parse_simple_trace(self) -> None:
+        """Parse a simple ReAct trace."""
+        parser = ReActParser()
+        text = """Thought: I need to search for information
+Action: search
+Action Input: {"query": "test"}
+Observation: Found some results
+Final Answer: The answer is 42"""
+
+        steps = parser.parse(text)
+
+        assert len(steps) == 4
+        assert steps[0].step_type == "thought"
+        assert "search for information" in steps[0].content
+        assert steps[1].step_type == "action"
+        assert steps[1].tool_call is not None
+        assert steps[1].tool_call.name == "search"
+        assert steps[2].step_type == "observation"
+        assert steps[3].step_type == "final_answer"
+        assert "42" in steps[3].content
+
+    def test_parse_multiple_actions(self) -> None:
+        """Parse trace with multiple action cycles."""
+        parser = ReActParser()
+        text = """Thought: First I need to search
+Action: search
+Action Input: {"q": "first"}
+Observation: Result 1
+Thought: Now I need more info
+Action: search
+Action Input: {"q": "second"}
+Observation: Result 2
+Final Answer: Combined answer"""
+
+        steps = parser.parse(text)
+
+        # 2 thoughts + 2 actions + 2 observations + 1 final = 7
+        assert len(steps) == 7
+        action_steps = [s for s in steps if s.step_type == "action"]
+        assert len(action_steps) == 2
+        assert action_steps[0].tool_call.input == {"q": "first"}
+        assert action_steps[1].tool_call.input == {"q": "second"}
+
+    def test_parse_with_valid_json_input(self) -> None:
+        """Parse action with valid JSON input."""
+        parser = ReActParser()
+        text = """Action: api_call
+Action Input: {"endpoint": "/users", "method": "GET", "params": {"id": 123}}
+Observation: Success"""
+
+        steps = parser.parse(text)
+
+        assert len(steps) == 2
+        assert steps[0].tool_call is not None
+        assert steps[0].tool_call.input["endpoint"] == "/users"
+        assert steps[0].tool_call.input["method"] == "GET"
+        assert steps[0].tool_call.input["params"] == {"id": 123}
+
+    def test_parse_with_single_quote_json(self) -> None:
+        """Parse action with Python-style single quote dict."""
+        parser = ReActParser()
+        text = """Action: search
+Action Input: {'query': 'test value', 'limit': 10}
+Observation: Done"""
+
+        steps = parser.parse(text)
+
+        assert len(steps) == 2
+        assert steps[0].tool_call is not None
+        # Should handle single quotes
+        input_dict = steps[0].tool_call.input
+        assert "query" in input_dict or "raw" in input_dict
+
+    def test_parse_with_simple_string_input(self) -> None:
+        """Parse action with plain string input."""
+        parser = ReActParser()
+        text = """Action: search
+Action Input: just a simple query string
+Observation: Results"""
+
+        steps = parser.parse(text)
+
+        assert len(steps) == 2
+        assert steps[0].tool_call is not None
+        assert steps[0].tool_call.input.get("raw") == "just a simple query string"
+
+    def test_parse_malformed_json_input(self) -> None:
+        """Parse action with malformed/incomplete JSON."""
+        parser = ReActParser()
+        text = """Action: search
+Action Input: {query: test, missing quotes
+Observation: Still works"""
+
+        steps = parser.parse(text)
+
+        assert len(steps) == 2
+        assert steps[0].tool_call is not None
+        # Should fallback gracefully
+        assert "raw" in steps[0].tool_call.input or "query" in steps[0].tool_call.input
+
+    def test_parse_multiline_observation(self) -> None:
+        """Parse observation that spans multiple lines."""
+        parser = ReActParser()
+        text = """Thought: Searching
+Action: search
+Action Input: {"q": "test"}
+Observation: This is a long observation
+that spans multiple lines
+with various content
+including numbers 123 and symbols @#$
+Final Answer: Done"""
+
+        steps = parser.parse(text)
+
+        observation_steps = [s for s in steps if s.step_type == "observation"]
+        assert len(observation_steps) == 1
+        obs_content = observation_steps[0].content
+        assert "multiple lines" in obs_content
+        assert "123" in obs_content
+
+    def test_parse_multiline_json_input(self) -> None:
+        """Parse action input JSON that spans multiple lines."""
+        parser = ReActParser()
+        text = """Action: create
+Action Input: {
+    "name": "test",
+    "value": 123
+}
+Observation: Created"""
+
+        steps = parser.parse(text)
+
+        assert len(steps) == 2
+        assert steps[0].tool_call is not None
+        # Should combine multiline JSON
+        input_dict = steps[0].tool_call.input
+        assert input_dict.get("name") == "test" or "raw" in input_dict
+
+    def test_custom_prefixes(self) -> None:
+        """Parse with custom prefixes."""
+        parser = ReActParser(
+            thought_prefix="Thinking:",
+            action_prefix="Do:",
+            action_input_prefix="With:",
+            observation_prefix="Result:",
+        )
+        text = """Thinking: I should search
+Do: lookup
+With: {"term": "test"}
+Result: Found it"""
+
+        steps = parser.parse(text)
+
+        assert len(steps) == 3
+        assert steps[0].step_type == "thought"
+        assert steps[1].step_type == "action"
+        assert steps[1].tool_call.name == "lookup"
+        assert steps[2].step_type == "observation"
+
+    def test_parse_to_response(self) -> None:
+        """parse_to_response wraps in AgentResponse."""
+        parser = ReActParser()
+        text = """Thought: Thinking
+Action: do
+Action Input: {}
+Observation: Done
+Final Answer: The result is 42"""
+
+        response = parser.parse_to_response(text)
+
+        assert response.answer == "The result is 42"
+        assert len(response.steps) == 4
+
+    def test_parse_to_response_with_explicit_answer(self) -> None:
+        """parse_to_response uses explicit answer if provided."""
+        parser = ReActParser()
+        text = """Thought: Thinking
+Final Answer: Wrong answer"""
+
+        response = parser.parse_to_response(text, answer="Correct answer")
+
+        assert response.answer == "Correct answer"
+
+    def test_parse_empty_input(self) -> None:
+        """Parse empty input returns empty list."""
+        parser = ReActParser()
+
+        assert parser.parse("") == []
+        assert parser.parse("   ") == []
+        assert parser.parse("\n\n") == []
+
+    def test_parse_no_final_answer(self) -> None:
+        """Parse trace without Final Answer extracts from observation."""
+        parser = ReActParser()
+        text = """Thought: Let me search
+Action: search
+Action Input: {"q": "test"}
+Observation: The answer is Paris"""
+
+        response = parser.parse_to_response(text)
+
+        assert "Paris" in response.answer
+
+    def test_tool_call_output_updated(self) -> None:
+        """Observation updates the corresponding tool call output."""
+        parser = ReActParser()
+        text = """Action: search
+Action Input: {"q": "test"}
+Observation: Search results here"""
+
+        steps = parser.parse(text)
+
+        assert len(steps) == 2
+        assert steps[0].tool_call is not None
+        assert steps[0].tool_call.output == "Search results here"
+
+    def test_parse_key_value_input(self) -> None:
+        """Parse action input with key=value format."""
+        parser = ReActParser()
+        text = """Action: search
+Action Input: query=test, limit=10
+Observation: Done"""
+
+        steps = parser.parse(text)
+
+        assert len(steps) == 2
+        input_dict = steps[0].tool_call.input
+        # Should extract key-value pairs
+        assert "query" in input_dict or "raw" in input_dict
+
+
+# =============================================================================
+# ReActAdapter Tests
+# =============================================================================
+
+
+class TestReActAdapter:
+    """Tests for ReActAdapter."""
+
+    @pytest.mark.asyncio
+    async def test_async_agent(self) -> None:
+        """Wrap an async agent."""
+
+        async def async_agent(question: str) -> str:
+            return f"""Thought: Processing {question}
+Action: answer
+Action Input: {{"response": "42"}}
+Observation: Answered
+Final Answer: 42"""
+
+        adapter = ReActAdapter(async_agent)
+        response = await adapter.query("What is the answer?")
+
+        assert response.answer == "42"
+        assert len(response.steps) > 0
+        assert response.total_latency_ms > 0
+
+    @pytest.mark.asyncio
+    async def test_sync_agent(self) -> None:
+        """Wrap a sync agent."""
+
+        def sync_agent(question: str) -> str:
+            return f"""Thought: Got {question}
+Final Answer: Sync response"""
+
+        adapter = ReActAdapter(sync_agent)
+        response = await adapter.query("Test?")
+
+        assert response.answer == "Sync response"
+
+    @pytest.mark.asyncio
+    async def test_custom_parser(self) -> None:
+        """Use custom parser with adapter."""
+
+        async def agent(_: str) -> str:
+            return """Thinking: Custom format
+Do: action
+With: {}
+Result: Done"""
+
+        custom_parser = ReActParser(
+            thought_prefix="Thinking:",
+            action_prefix="Do:",
+            action_input_prefix="With:",
+            observation_prefix="Result:",
+        )
+
+        adapter = ReActAdapter(agent, parser=custom_parser)
+        response = await adapter.query("Test")
+
+        assert len(response.steps) == 3
+
+    @pytest.mark.asyncio
+    async def test_custom_answer_extractor(self) -> None:
+        """Use custom answer extractor."""
+
+        async def agent(_: str) -> str:
+            return """Some output
+ANSWER: Custom extracted"""
+
+        def extract(output: str) -> str:
+            for line in output.split("\n"):
+                if line.startswith("ANSWER:"):
+                    return line[7:].strip()
+            return ""
+
+        adapter = ReActAdapter(agent, extract_answer=extract)
+        response = await adapter.query("Test")
+
+        assert response.answer == "Custom extracted"
+
+    @pytest.mark.asyncio
+    async def test_metadata_populated(self) -> None:
+        """Response metadata is populated."""
+
+        async def agent(_: str) -> str:
+            return "Final Answer: Done"
+
+        adapter = ReActAdapter(agent)
+        response = await adapter.query("Test")
+
+        assert response.metadata["adapter"] == "react"
+        assert "raw_output_length" in response.metadata
+
+
+# =============================================================================
+# ChainOfThoughtAdapter Tests
+# =============================================================================
+
+
+class TestChainOfThoughtAdapter:
+    """Tests for ChainOfThoughtAdapter."""
+
+    @pytest.fixture
+    def mock_llm(self) -> AsyncMock:
+        """Create mock LLM."""
+        llm = AsyncMock()
+        llm.is_local = True
+        return llm
+
+    @pytest.mark.asyncio
+    async def test_basic_cot(self, mock_llm: AsyncMock) -> None:
+        """Basic CoT reasoning."""
+        mock_llm.generate.return_value = """First, I need to understand the problem.
+
+Then, I'll break it down into parts.
+
+Finally, the answer is 42."""
+
+        adapter = ChainOfThoughtAdapter(mock_llm)
+        response = await adapter.query("What is the answer?")
+
+        assert "42" in response.answer
+        assert len(response.steps) >= 2
+
+    @pytest.mark.asyncio
+    async def test_step_separation(self, mock_llm: AsyncMock) -> None:
+        """Steps are separated correctly."""
+        mock_llm.generate.return_value = """Step 1: Analyze the input.
+
+Step 2: Process the data.
+
+Step 3: Therefore, the answer is X."""
+
+        adapter = ChainOfThoughtAdapter(mock_llm)
+        response = await adapter.query("Process this")
+
+        thought_steps = [s for s in response.steps if s.step_type == "thought"]
+        assert len(thought_steps) >= 2
+
+    @pytest.mark.asyncio
+    async def test_custom_cot_prompt(self, mock_llm: AsyncMock) -> None:
+        """Custom CoT prompt is used."""
+        mock_llm.generate.return_value = "The answer is 5."
+
+        adapter = ChainOfThoughtAdapter(
+            mock_llm,
+            cot_prompt="Think carefully step by step:",
+        )
+        await adapter.query("2+3=?")
+
+        # Check that prompt was built correctly
+        call_args = mock_llm.generate.call_args[0][0]
+        assert "Think carefully step by step:" in call_args
+
+    @pytest.mark.asyncio
+    async def test_custom_step_separator(self, mock_llm: AsyncMock) -> None:
+        """Custom step separator works."""
+        mock_llm.generate.return_value = "First---Second---Third"
+
+        adapter = ChainOfThoughtAdapter(mock_llm, step_separator="---")
+        response = await adapter.query("Test")
+
+        assert len(response.steps) == 3
+
+    @pytest.mark.asyncio
+    async def test_answer_prefix(self, mock_llm: AsyncMock) -> None:
+        """Answer prefix extracts explicit answer."""
+        mock_llm.generate.return_value = """Let me think about this.
+
+I'll consider the options.
+
+ANSWER: The final result is 100."""
+
+        adapter = ChainOfThoughtAdapter(mock_llm, answer_prefix="ANSWER:")
+        response = await adapter.query("Calculate")
+
+        assert "100" in response.answer
+
+    @pytest.mark.asyncio
+    async def test_metadata_populated(self, mock_llm: AsyncMock) -> None:
+        """Response metadata is populated."""
+        mock_llm.generate.return_value = "Simple answer"
+
+        adapter = ChainOfThoughtAdapter(mock_llm)
+        response = await adapter.query("Test")
+
+        assert response.metadata["adapter"] == "chain_of_thought"
+        assert "cot_prompt" in response.metadata
+        assert response.total_latency_ms >= 0
+
+    @pytest.mark.asyncio
+    async def test_numbered_steps(self, mock_llm: AsyncMock) -> None:
+        """Parse numbered step format."""
+        mock_llm.generate.return_value = """1. First step of reasoning
+2. Second step with more detail
+3. Third step concluding
+4. The answer is 42"""
+
+        adapter = ChainOfThoughtAdapter(mock_llm, step_separator="\n\n")
+        response = await adapter.query("Test")
+
+        # Should detect numbered format
+        assert len(response.steps) >= 1
+
+    @pytest.mark.asyncio
+    async def test_empty_response(self, mock_llm: AsyncMock) -> None:
+        """Handle empty LLM response."""
+        mock_llm.generate.return_value = ""
+
+        adapter = ChainOfThoughtAdapter(mock_llm)
+        response = await adapter.query("Test")
+
+        assert response.answer == ""
+        assert response.steps == []
+
+    @pytest.mark.asyncio
+    async def test_conclusion_detection(self, mock_llm: AsyncMock) -> None:
+        """Detect conclusion markers."""
+        mock_llm.generate.return_value = """First I analyze.
+
+Then I process.
+
+Therefore, the answer is 7."""
+
+        adapter = ChainOfThoughtAdapter(mock_llm)
+        response = await adapter.query("Test")
+
+        # Should detect "therefore" as conclusion
+        final_steps = [s for s in response.steps if s.step_type == "final_answer"]
+        assert len(final_steps) == 1
+
+
+# =============================================================================
+# Integration Tests
+# =============================================================================
+
+
+class TestIntegration:
+    """Integration tests for adapters."""
+
+    @pytest.mark.asyncio
+    async def test_react_adapter_implements_protocol(self) -> None:
+        """ReActAdapter response works with AgentProtocol."""
+
+        async def agent(_: str) -> str:
+            return "Final Answer: Test"
+
+        adapter = ReActAdapter(agent)
+
+        # Check protocol compatibility
+        assert hasattr(adapter, "query")
+        response = await adapter.query("Test")
+        assert hasattr(response, "answer")
+        assert hasattr(response, "steps")
+
+    @pytest.mark.asyncio
+    async def test_cot_adapter_with_evaluator(self) -> None:
+        """CoT adapter works with efficiency evaluator."""
+        from ragnarok_ai.agents.evaluators import ReasoningEfficiencyEvaluator
+
+        mock_llm = AsyncMock()
+        mock_llm.generate.return_value = """Step 1.
+
+Step 2.
+
+Step 3."""
+
+        adapter = ChainOfThoughtAdapter(mock_llm)
+        response = await adapter.query("Test")
+
+        evaluator = ReasoningEfficiencyEvaluator()
+        result = evaluator.evaluate(response, optimal_steps=3)
+
+        assert result.actual_steps == len(response.steps)


### PR DESCRIPTION
## Summary

- `ReActParser`: parse ReAct traces to `list[AgentStep]`
  - Handles JSON, single-quote dict, plain string inputs
  - Multiline observations support
  - Customizable prefixes
- `ReActAdapter`: wrap ReAct agents for evaluation
- `ChainOfThoughtAdapter`: evaluate CoT reasoning

## Test plan

- [x] 31 unit tests including edge cases
- [x] Full test suite passes (1106 tests)
- [x] Lint and mypy pass

Closes #63