### PR TITLE
chore: add dual licensing (AGPL-3.0 + Commercial)

### DIFF
--- a/LICENSE-COMMERCIAL.md
+++ b/LICENSE-COMMERCIAL.md
@@ -1,0 +1,76 @@
+# Commercial License for RAGnarok-AI
+
+Copyright (c) 2026 Abdelatif Touati. All rights reserved.
+
+## Overview
+
+RAGnarok-AI is dual-licensed:
+
+1. **Open Source License (AGPL-3.0)** — Free for open source projects and personal use, with copyleft obligations.
+2. **Commercial License** — For organizations that cannot or do not wish to comply with AGPL-3.0 terms.
+
+## When You Need a Commercial License
+
+You need a commercial license if:
+
+- You want to use RAGnarok-AI in proprietary software without publishing your source code
+- You want to use RAGnarok-AI in a SaaS product without open-sourcing your service
+- Your organization's legal policy prohibits AGPL-licensed software
+- You want to receive priority support and custom development
+
+## Commercial License Terms
+
+### Grant of License
+
+Subject to the terms of a signed commercial agreement, Licensor grants Licensee a non-exclusive, non-transferable, limited license to use RAGnarok-AI for internal business purposes.
+
+### What Is Included
+
+- Right to use RAGnarok-AI without AGPL copyleft obligations
+- No requirement to publish modifications or derivative works
+- Right to integrate with proprietary systems
+- Support during the term of the agreement (if specified)
+
+### What Is NOT Included
+
+- **No ownership transfer** — RAGnarok-AI remains the exclusive property of Abdelatif Touati
+- **No redistribution rights** — You may not sublicense, sell, or distribute RAGnarok-AI
+- **No rights to core improvements** — Any improvements to RAGnarok-AI core made by Licensor remain Licensor's property
+- **No exclusivity** — Licensor may license RAGnarok-AI to other parties
+
+### Custom Development
+
+For consulting engagements:
+
+| Component | Ownership |
+|-----------|-----------|
+| RAGnarok-AI core | Licensor (Abdelatif Touati) |
+| Custom adapters and integrations | Client (work-for-hire) |
+| Reports, metrics, recommendations | Client (deliverables) |
+| Core improvements and bug fixes | Licensor (Abdelatif Touati) |
+
+### Term and Termination
+
+- License is valid for the duration specified in the commercial agreement
+- Upon termination, Licensee must cease using RAGnarok-AI
+- Termination does not affect ownership of custom deliverables created during the engagement
+
+## Pricing
+
+Commercial licenses are negotiated on a case-by-case basis depending on:
+
+- Scope of use (single project vs. organization-wide)
+- Duration
+- Support requirements
+- Custom development needs
+
+## Contact
+
+For commercial licensing inquiries:
+
+**Abdelatif Touati**
+Email: abdel.touati@gmail.com
+
+---
+
+*This document is for informational purposes. Actual commercial license terms are defined in individual agreements between Licensor and Licensee.*

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,67 @@
+RAGnarok-AI
+Copyright (c) 2026 Abdelatif Touati
+
+================================================================================
+DUAL LICENSING
+================================================================================
+
+This software is available under two licensing options:
+
+1. OPEN SOURCE LICENSE (AGPL-3.0)
+
+   RAGnarok-AI is free software: you can redistribute it and/or modify it under
+   the terms of the GNU Affero General Public License as published by the Free
+   Software Foundation, either version 3 of the License, or (at your option)
+   any later version.
+
+   This program is distributed in the hope that it will be useful, but WITHOUT
+   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+   FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+   details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+   Full license text: LICENSE
+
+2. COMMERCIAL LICENSE
+
+   For organizations that cannot comply with AGPL-3.0 terms, a commercial
+   license is available. The commercial license permits use without copyleft
+   obligations.
+
+   Commercial license details: LICENSE-COMMERCIAL.md
+   Contact: abdel.touati@gmail.com
+
+================================================================================
+INTELLECTUAL PROPERTY
+================================================================================
+
+RAGnarok-AI and all associated intellectual property rights are owned
+exclusively by Abdelatif Touati.
+
+- The RAGnarok-AI name, logo, and branding are proprietary
+- Core source code is owned by Abdelatif Touati
+- Contributions are accepted under the terms of the AGPL-3.0 license
+
+================================================================================
+THIRD-PARTY COMPONENTS
+================================================================================
+
+RAGnarok-AI includes or depends on third-party open source components. These
+components are licensed under their respective licenses:
+
+- pydantic: MIT License
+- httpx: BSD License
+- pytest: MIT License
+- ruff: MIT License
+
+See pyproject.toml for the complete list of dependencies.
+
+================================================================================
+CONTACT
+================================================================================
+
+Abdelatif Touati
+Email: abdel.touati@gmail.com
+GitHub: https://github.com/2501Pr0ject/RAGnarok-AI

--- a/README.md
+++ b/README.md
@@ -494,9 +494,18 @@ Contributions are welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) for gu
 
 ## License
 
-This project is licensed under the [AGPL-3.0 License](LICENSE).
+RAGnarok-AI is dual-licensed:
 
-**Why AGPL?** To ensure improvements stay open-source and prevent the "open-core bait-and-switch" model where companies take OSS code and monetize without contributing back.
+| License | Use Case |
+|---------|----------|
+| [AGPL-3.0](LICENSE) | Open source projects, personal use, research |
+| [Commercial](LICENSE-COMMERCIAL.md) | Proprietary software, SaaS, organizations with AGPL restrictions |
+
+**Why dual licensing?**
+- AGPL ensures improvements stay open-source
+- Commercial license enables enterprise adoption without copyleft obligations
+
+For commercial licensing inquiries: abdel.touati@gmail.com
 
 ---
 


### PR DESCRIPTION
## Summary

Add dual licensing to protect IP while enabling commercial consulting.

## Changes

- **LICENSE-COMMERCIAL.md**: Commercial license terms for clients
  - Non-exclusive, non-transferable usage rights
  - Clear IP separation (core vs custom work)
  - No redistribution rights
  
- **NOTICE**: Legal notice with copyright and licensing info

- **README.md**: Updated license section to reflect dual licensing

## IP Model

| Component | Ownership |
|-----------|-----------|
| RAGnarok-AI core | Abdelatif Touati |
| Custom adapters/integrations | Client |
| Reports, metrics, recommendations | Client (deliverables) |
| Core improvements | Abdelatif Touati |